### PR TITLE
Add pagination for getNftsForCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ const alchemy = initializeAlchemy(settings);
 The SDK's modular approach exports all functions at the top-level to reduce bundle size. However,
 this can make it harder to discover the full API surface. If you want your IDE to find all functions, you can import
 the entire SDK:
+
 ```ts
 import * as alchemySdk from 'exploring-pioneer';
 
 const alchemy = alchemySdk.initializeAlchemy();
-alchemySdk.getNfts(alchemy, {owner: '0x123'});
+alchemySdk.getNfts(alchemy, { owner: '0x123' });
 ```
 
 ## SDK Structure

--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -27,7 +27,9 @@ export class BaseNft {
   static fromResponse(ownedNft: RawBaseNft, contractAddress: string): BaseNft {
     return new BaseNft(
       contractAddress,
-      ownedNft.id.tokenId,
+      // We have to normalize the token id here since the backend sometimes
+      // returns the token ID as a hex string and sometimes as an integer.
+      normalizeTokenIdToHex(ownedNft.id.tokenId),
       ownedNft.id.tokenMetadata?.tokenType ?? NftTokenType.UNKNOWN
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
   getNfts,
   getNftsPaginated,
   getNftsForCollection,
+  getNftsForCollectionPaginated,
   getOwnersForToken
 } from './api/nft-api';
 

--- a/src/internal/dispatch.ts
+++ b/src/internal/dispatch.ts
@@ -79,13 +79,15 @@ function isRetryableHttpError(err: AxiosError): boolean {
  * @internal
  */
 export async function* paginateEndpoint<
-  PageKey extends string,
-  Req extends Partial<Record<PageKey, string>>,
-  Res extends Partial<Record<string, any> & Record<PageKey, string>>
+  ReqPageKey extends string,
+  ResPageKey extends string,
+  Req extends Partial<Record<string, any> & Record<ReqPageKey, string>>,
+  Res extends Partial<Record<string, any> & Record<ResPageKey, string>>
 >(
   alchemy: Alchemy,
   methodName: string,
-  pageKey: PageKey,
+  reqPageKey: ReqPageKey,
+  resPageKey: ResPageKey,
   params: Req
 ): AsyncIterable<Res> {
   let hasNext = true;
@@ -97,9 +99,8 @@ export async function* paginateEndpoint<
       requestParams
     );
     yield response;
-    if (response[pageKey] !== undefined) {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      requestParams[pageKey] = response[pageKey] as any;
+    if (response[resPageKey] !== undefined) {
+      requestParams[reqPageKey] = response[resPageKey] as any;
     } else {
       hasNext = false;
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -282,7 +282,8 @@ export interface RawContract {
 }
 
 /**
- * Parameters object for the {@link getNftsForCollection} function.
+ * Parameters object for the {@link getNftsForCollection} and
+ * {@link getNftsForCollectionPaginated} functions.
  *
  * This interface is used to fetch NFTs with their associated metadata. To get
  * Nfts without their associated metadata, use
@@ -307,7 +308,8 @@ export interface GetNftsForCollectionParams {
 }
 
 /**
- * Parameters object for the {@link getNftsForCollection} function.
+ * Parameters object for the {@link getNftsForCollection} and
+ * {@link getNftsForCollectionPaginated} functions.
  *
  * This interface is used to fetch NFTs without their associated metadata. To
  * get Nfts with their associated metadata, use

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -9,6 +9,7 @@ export function formatBlock(block: string | number): string {
   return block.toString();
 }
 
+// TODO: Add loglevel options to avoid always logging everything
 export function logger(methodName: string, message: string) {
   console.log(`[${methodName}]: ${message}`);
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -8,6 +8,7 @@ import {
   NftTokenType
 } from '../src';
 import { Alchemy } from '../src/api/alchemy';
+import { getNftsForCollectionPaginated } from '../src/api/nft-api';
 
 /**
  * Temporary test
@@ -116,5 +117,23 @@ describe('E2E integration tests', () => {
       totalCount += 1;
     }
     console.log('done', allNfts.length, allNfts);
+  });
+
+  it('getNftsForCollectionPaginated', async () => {
+    jest.setTimeout(15000);
+    console.log('lets paginate');
+    const allNfts = [];
+    let totalCount = 0;
+    for await (const nft of getNftsForCollectionPaginated(alchemy, {
+      contractAddress,
+      withMetadata: false
+    })) {
+      if (totalCount === 150) {
+        break;
+      }
+      allNfts.push(nft);
+      totalCount += 1;
+    }
+    console.log('done', allNfts.length, allNfts[100], totalCount);
   });
 });

--- a/test/nft.test.ts
+++ b/test/nft.test.ts
@@ -3,7 +3,7 @@ import { createNft, createRawBaseNft, createRawNft } from './test-util';
 
 describe('BaseNft class', () => {
   const contractAddress = '0xCA1';
-  const tokenId = '0x1';
+  const tokenId = '0x01';
   it('fromResponse() defaults to UNKNOWN token type', () => {
     const nft = BaseNft.fromResponse(
       createRawBaseNft(tokenId),
@@ -12,6 +12,22 @@ describe('BaseNft class', () => {
     expect(nft.tokenType).toEqual(NftTokenType.UNKNOWN);
     expect(nft.tokenId).toEqual(tokenId);
     expect(nft.address).toEqual(contractAddress);
+  });
+
+  it('fromResponse() normalizes tokenId fields', () => {
+    const tokenIdIntegerAsString = '42';
+    const tokenIdHex = toHex(42);
+    let nft = BaseNft.fromResponse(
+      createRawBaseNft(tokenIdHex),
+      contractAddress
+    );
+    expect(nft.tokenId).toEqual(tokenIdHex);
+
+    nft = BaseNft.fromResponse(
+      createRawBaseNft(tokenIdIntegerAsString),
+      contractAddress
+    );
+    expect(nft.tokenId).toEqual(tokenIdHex);
   });
 });
 


### PR DESCRIPTION
- Adding a pagination endpoint for `getNftsForCollection`
- Adds token normalization to `BaseNft` to normalize differing Alchemy endpoint responses 
