### PR TITLE
Add NFT filter param to getNfts()

### DIFF
--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -26,7 +26,7 @@ export class BaseNft {
    */
   protected constructor(
     address: string,
-    /** The NFT token ID as a hex string */
+    /** The NFT token ID as a hex string. */
     readonly tokenId: string,
     /** The type of ERC token, if known. */
     readonly tokenType: NftTokenType

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -197,6 +197,12 @@ export interface GetNftsParams {
   /** Optional list of contract addresses to filter the results by. Limit is 20. */
   contractAddresses?: string[];
 
+  /**
+   * Optional list of filters applied to the query. NFTs that match one or more
+   * of these filters are excluded from the response.
+   */
+  excludeFilters?: NftExcludeFilters[];
+
   /** Optional boolean flag to omit NFT metadata. Defaults to `false`. */
   omitMetadata?: boolean;
 }
@@ -222,8 +228,25 @@ export interface GetBaseNftsParams {
   /** Optional list of contract addresses to filter the results by. Limit is 20. */
   contractAddresses?: string[];
 
+  /**
+   * Optional list of filters applied to the query. NFTs that match one or more
+   * of these filters are excluded from the response.
+   */
+  excludeFilters?: NftExcludeFilters[];
+
   /** Optional boolean flag to include NFT metadata. Defaults to `false`. */
   omitMetadata: true;
+}
+
+/**
+ * Enum of NFT filters that can be applied to a {@link getNfts} request. NFTs
+ * that match one or more of these filters are excluded from the response.
+ *
+ * @beta
+ */
+export enum NftExcludeFilters {
+  /** Exclude NFTs that have been classified as spam. */
+  SPAM
 }
 
 /**

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -7,6 +7,7 @@ import {
   getNftsPaginated,
   getOwnersForToken,
   initializeAlchemy,
+  NftExcludeFilters,
   NftTokenType
 } from '../src';
 
@@ -58,8 +59,10 @@ describe('E2E integration tests', () => {
   it('getOwnersForToken from NFT', async () => {
     const nfts = await getNfts(alchemy, {
       owner: ownerAddress,
+      excludeFilters: [NftExcludeFilters.SPAM],
       omitMetadata: true
     });
+    console.log('nfts', nfts);
     const owners = await getOwnersForToken(alchemy, nfts.ownedNfts[0]);
     console.log('owner', owners);
   });

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -10,9 +10,11 @@ import {
   getNftsForCollection,
   getNftsForCollectionPaginated,
   getNftsPaginated,
+  GetNftsParams,
   getOwnersForToken,
   initializeAlchemy,
   Nft,
+  NftExcludeFilters,
   NftTokenType,
   OwnedBaseNft,
   OwnedBaseNftsResponse,
@@ -164,10 +166,12 @@ describe('NFT module', () => {
     const ownerAddress = '0xABC';
     const pageKey = 'page-key0';
     const contractAddresses = ['0xCA1', '0xCA2'];
-    const getNftsParams = {
+    const excludeFilters = [NftExcludeFilters.SPAM];
+    const getNftsParams: GetNftsParams = {
       owner: ownerAddress,
       pageKey,
-      contractAddresses
+      contractAddresses,
+      excludeFilters
     };
     const baseNftResponse: RawGetBaseNftsResponse = {
       ownedNfts: [
@@ -208,6 +212,10 @@ describe('NFT module', () => {
         expect(mock.history.get[0].params).toHaveProperty(
           'contractAddresses',
           contractAddresses
+        );
+        expect(mock.history.get[0].params).toHaveProperty(
+          'filters',
+          excludeFilters
         );
         expect(mock.history.get[0].params).toHaveProperty('pageKey', pageKey);
         expect(mock.history.get[0].params).toHaveProperty(


### PR DESCRIPTION
Adding filters to `getNfts()`. Documentation for filters can be found [here](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/getnfts#parameters). I renamed `filters` to `excludeFilters` in case getNfts eventually supports other querying filters + it seemed easier to conceptualize. I can also rename to `filters` to match the REST API, but at this point, the SDK has already diverged from the REST endpoints.

cc @niveda-krish 