### PR TITLE
Add findContractDeployer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The SDK currently supports the following NFT endpoints:
 - `getNftForCollectionPaginated()`: Gets all NFTs for a contract address, paginated.
 - `getOwnersForToken()`: Get all the owners for a given NFT contract address and token ID.
 - `checkOwnership()`: Checks that the provided owner address owns one or more of the provided NFT contract addresses.
+- `findContractDeployer()`: Finds the contract deployer and block number for a given NFT contract address.
 
 ### Comparing `BaseNft` and `Nft`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ export {
   getNftsForCollection,
   getNftsForCollectionPaginated,
   getOwnersForToken,
-  checkOwnership
+  checkOwnership,
+  findContractDeployer
 } from './api/nft-api';
 
 export {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -435,3 +435,16 @@ export interface CollectionNftsResponse {
    */
   pageKey?: string;
 }
+
+/**
+ * The response object for the {@link findContractDeployer} function.
+ *
+ * @public
+ */
+export interface DeployResult {
+  /** The address of the contract deployer, if it is available. */
+  readonly deployerAddress?: string;
+
+  /** The block number the contract was deployed in. */
+  readonly blockNumber: number;
+}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,6 @@
 import {
   Alchemy,
+  findContractDeployer,
   getNftMetadata,
   getNfts,
   getNftsForCollection,
@@ -24,6 +25,27 @@ describe('E2E integration tests', () => {
     // Skip all timeouts for testing.
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout').mockImplementation((f: any) => f());
+  });
+
+  // TODO: add unit test coverage. Integration tests are just sanity tests for now.
+  it('findContractDeployer()', async () => {
+    // BAYC
+    let contractAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
+    let contractDeployer = await findContractDeployer(alchemy, contractAddress);
+    expect(contractDeployer.deployerAddress).toEqual(
+      '0xaba7161a7fb69c88e16ed9f455ce62b791ee4d03'
+    );
+    expect(contractDeployer.blockNumber).toEqual(12287507);
+    console.log(contractDeployer);
+
+    // ENS
+    contractAddress = '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85';
+    contractDeployer = await findContractDeployer(alchemy, contractAddress);
+    expect(contractDeployer.deployerAddress).toEqual(
+      '0x4fe4e666be5752f1fdd210f4ab5de2cc26e3e0e8'
+    );
+    expect(contractDeployer.blockNumber).toEqual(9380410);
+    console.log(contractDeployer);
   });
 
   it('getNftMetadata', async () => {

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -854,4 +854,13 @@ describe('NFT module', () => {
       );
     });
   });
+
+  // TODO: add unit test coverage for the endpoint after overriding the ethers.js
+  // AlchemyProvider class, which would make mocking returns much easier.
+  describe('findContractDeployer()', () => {
+    it('binary search works', async () => {});
+    it('validates that the address is a contract', async () => {});
+    it('handles upper case input', async () => {});
+    it('handles errors', async () => {});
+  });
 });


### PR DESCRIPTION
Adding a binary search implementation that @pileofscraps created to find the deployer of a contract. Hoping that the backend team will ingest the data and serve it in the future.

I wanted to add more unit test coverage but mocking out the provider returns from ethers directly right now isn't easy. Plan is to punt on it until after one of the following happens:
1. we rewrite ethers handlers with our own or
2. NFT API adds rest endpoint for this. 
3. We move alchemy enhanced endpoints to use the axios implementation instead of ethers.

In the interim, I ran the tests with several actual contract addresses for now and added an integration test. 