### PR TITLE
Add gzip header for compression

### DIFF
--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -13,6 +13,7 @@ import {
 } from '../util/const';
 import { Network } from '../types/types';
 import { logWarn } from '../util/logger';
+import { VERSION } from '../version';
 
 /**
  * SDK's custom implementation of ethers' {@link providers.AlchemyProvider}.
@@ -110,7 +111,8 @@ export class AlchemyProvider
         : getAlchemyWsUrl(network, apiKey);
     return {
       headers: {
-        'Alchemy-Ethers-Sdk-Version': '1.0.0'
+        'Alchemy-Ethers-Sdk-Version': VERSION,
+        'Accept-Encoding': 'gzip'
       },
       allowGzip: true,
       url

--- a/src/util/sendRest.ts
+++ b/src/util/sendRest.ts
@@ -19,7 +19,8 @@ export function sendAxiosRequest<Req, Res>(
   const methodUrl = baseUrl + '/' + methodName;
   const config: AxiosRequestConfig = {
     headers: {
-      'Alchemy-Ethers-Sdk-Version': VERSION
+      'Alchemy-Ethers-Sdk-Version': VERSION,
+      'Accept-Encoding': 'gzip'
     },
     method: 'get',
     url: methodUrl,


### PR DESCRIPTION
Add gzip header to use compression.

TESTING
- Verified that curl commands work and return compressed response
- Used `decompress: false` option in axios to verify SDK receives compressed response
- Verified e2e requests still work fine