### PR TITLE
Revert .mjs support and stick with .cjs for node import

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "exports": {
     "node": {
       "require": "./dist/index.cjs.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.cjs.js"
     },
-    "default": "./dist/index.esm.js",
-    "package.json": "./package.json"
+    "package.json": "./package.json",
+    "default": "./dist/index.esm.js"
   },
   "types": "./dist/src/index.d.ts",
   "repository": {


### PR DESCRIPTION
The rabbithole uncovered by exporting `es` modules for node imports is not worth the complexity right now. I ran into a lot of issues with `require` vs `import` when using websockets.

This PR uses the CJS build for both. Will revisit fixing `es` exports if there is sufficient developer demand one day.