### PR TITLE
tree shaking improvements

### DIFF
--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -1,4 +1,4 @@
-import { providers } from 'ethers';
+import * as providers from '@ethersproject/providers';
 import {
   Network as NetworkFromEthers,
   Networkish
@@ -49,8 +49,8 @@ export class AlchemyProvider
   }
 
   /**
-   * Overrides the {@link UrlJsonRpcProvider.getApiKey} method as implemented by
-   * ethers.js. Returns the API key for an Alchemy provider.
+   * Overrides the {@link providers.UrlJsonRpcProvider.getApiKey} method as
+   * implemented by ethers.js. Returns the API key for an Alchemy provider.
    *
    * @internal
    * @override

--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -1,4 +1,5 @@
-import { BigNumber, providers } from 'ethers';
+import * as providers from '@ethersproject/providers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { Networkish } from '@ethersproject/networks';
 import { DEFAULT_ALCHEMY_API_KEY, EthersNetwork, noop } from '../util/const';
 import { AlchemyProvider } from './alchemy-provider';

--- a/src/api/nft-api.ts
+++ b/src/api/nft-api.ts
@@ -34,7 +34,7 @@ import {
 } from '../internal/raw-interfaces';
 import { toHex } from './util';
 import { getTransactionReceipts } from './enhanced';
-import { BigNumber, BigNumberish } from 'ethers';
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { AlchemyApiType } from '../util/const';
 import {
   getNftContractFromRaw,

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 
 /**
  * Converts a hex string to a decimal number.

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { BaseNft, BaseNftContract, Nft, NftContract } from '../api/nft';
 import { toHex } from '../api/util';
 import {

--- a/test/integration/provider.test.ts
+++ b/test/integration/provider.test.ts
@@ -1,4 +1,5 @@
-import { providers, Transaction } from 'ethers';
+import * as providers from '@ethersproject/providers';
+import { Transaction } from '@ethersproject/transactions';
 import { initializeAlchemy } from '../../src';
 import { EthersNetwork } from '../../src/util/const';
 

--- a/test/unit/websocket-provider.test.ts
+++ b/test/unit/websocket-provider.test.ts
@@ -13,7 +13,7 @@ import {
   NewHeadsEvent,
   WebsocketBackfiller
 } from '../../src/internal/websocket-backfiller';
-import { Formatter } from '@ethersproject/providers/lib/formatter';
+import { Formatter } from '@ethersproject/providers';
 import SpyInstance = jest.SpyInstance;
 
 describe('AlchemyWebSocketProvider', () => {


### PR DESCRIPTION
- Replaced all imports from the umbrella package `ethers` to `@ethersproject/*` equivalents.

This reduces the bundle size of a CRA app using `initializeAlchemy()` from 605 KB to 551 KB.
|Before|After|
|--|--|
|![Screen Shot 2022-07-01 at 3 58 24 PM](https://user-images.githubusercontent.com/8624213/176961529-0109b2f5-ef5a-4e35-8938-4a4559338485.png)|![Screen Shot 2022-07-01 at 4 55 12 PM](https://user-images.githubusercontent.com/8624213/176966882-40cc4c16-efd3-42a8-b9d2-729424b2db3f.png)|