### PR TITLE
Remove 'lib/base-provider' dependency for reduced bundle size

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,19 +22,8 @@ const allBuilds = {
       sourcemap: true
     }
   ],
-  external: [
-    ...Object.keys(pkg.dependencies || {}),
-
-    // Needed for '/lib' import in AlchemyWebSocketProvider
-    '@ethersproject/providers/lib/base-provider'
-  ],
-  plugins: [
-    typescriptPlugin(),
-
-    // Needed to resolve `Event` class from Ethers in AlchemyWebSocketProvider
-    nodeResolve(),
-    commonjs()
-  ]
+  external: [...Object.keys(pkg.dependencies || {})],
+  plugins: [typescriptPlugin(), nodeResolve(), commonjs()]
 };
 
 export default allBuilds;

--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -3,7 +3,6 @@ import { Networkish } from '@ethersproject/networks';
 import { DEFAULT_ALCHEMY_API_KEY, EthersNetwork, noop } from '../util/const';
 import { AlchemyProvider } from './alchemy-provider';
 import { Listener } from '@ethersproject/abstract-provider';
-import { Event } from '@ethersproject/providers/lib/base-provider';
 import { AlchemyEventType } from '../types/types';
 import {
   BatchPart,
@@ -54,6 +53,7 @@ export class AlchemyWebSocketProvider
   extends WebSocketProvider
   implements CommunityResourcable
 {
+  _events: Array<EthersEvent> = [];
   readonly apiKey: string;
 
   // In the case of a WebSocket reconnection, all subscriptions are lost and we
@@ -236,7 +236,7 @@ export class AlchemyWebSocketProvider
     if (isAlchemyEvent(eventName)) {
       let result = false;
 
-      const stopped: Array<Event> = [];
+      const stopped: Array<EthersEvent> = [];
 
       // This line is the only modified line from the original method.
       const eventTag = getAlchemyEventTag(eventName);

--- a/src/internal/internal-types.ts
+++ b/src/internal/internal-types.ts
@@ -3,7 +3,7 @@ import {
   LogsSubscriptionFilter,
   NewHeadsEvent
 } from './websocket-backfiller';
-import { Event } from '@ethersproject/providers/lib/base-provider';
+import { EventType, Filter, Listener } from '@ethersproject/abstract-provider';
 
 type JsonRpcId = string | number | null;
 
@@ -59,7 +59,82 @@ export type WebSocketMessage = SingleOrBatchResponse | SubscriptionEvent;
 export type SingleOrBatchResponse = JsonRpcResponse | JsonRpcResponse[];
 
 /**
- * Wrapper class around the {@link Event} class in order to add support for
+ * DO NOT MODIFY.
+ *
+ * Event class copied directly over from ethers.js's `BaseProvider` class.
+ *
+ * This class is used to represent events and their corresponding listeners. The
+ * SDK needs to extend this class in order to support Alchemy's custom
+ * Subscription API types. The original class is not exported by ethers. Minimal
+ * changes have been made in order to get TS to compile.
+ */
+class Event {
+  readonly listener: Listener;
+  readonly once: boolean;
+  readonly tag: string;
+
+  _lastBlockNumber: number;
+  _inflight: boolean;
+
+  constructor(tag: string, listener: Listener, once: boolean) {
+    this.listener = listener;
+    this.tag = tag;
+    this.once = once;
+    this._lastBlockNumber = -2;
+    this._inflight = false;
+  }
+
+  get event(): EventType {
+    switch (this.type) {
+      case 'tx':
+        return this.hash!;
+      case 'filter':
+        return this.filter!;
+      default:
+        return this.tag;
+    }
+  }
+
+  get type(): string {
+    return this.tag.split(':')[0];
+  }
+
+  get hash(): string {
+    const comps = this.tag.split(':');
+    if (comps[0] !== 'tx') {
+      throw new Error('Not a transaction event');
+    }
+    return comps[1];
+  }
+
+  get filter(): Filter {
+    const comps = this.tag.split(':');
+    if (comps[0] !== 'filter') {
+      throw new Error('Not a transaction event');
+    }
+    const address = comps[1];
+
+    const topics = deserializeTopics(comps[2]);
+    const filter: Filter = {};
+
+    if (topics.length > 0) {
+      filter.topics = topics;
+    }
+    if (address && address !== '*') {
+      filter.address = address;
+    }
+
+    return filter;
+  }
+
+  pollable(): boolean {
+    const PollableEvents = ['block', 'network', 'pending', 'poll'];
+    return this.tag.indexOf(':') >= 0 || PollableEvents.indexOf(this.tag) >= 0;
+  }
+}
+
+/**
+ * Wrapper class around the ethers `Event` class in order to add support for
  * Alchemy's custom subscriptions types.
  *
  * @internal
@@ -86,4 +161,22 @@ export interface SubscriptionEvent<T = any> {
     subscription: string;
     result: T;
   };
+}
+
+function deserializeTopics(data: string): any {
+  if (data === '') {
+    return [];
+  }
+
+  return data.split(/&/g).map(topic => {
+    if (topic === '') {
+      return [];
+    }
+
+    const comps = topic.split('|').map(topic => {
+      return topic === 'null' ? null : topic;
+    });
+
+    return comps.length === 1 ? comps[0] : comps;
+  });
 }

--- a/test/integration/provider.test.ts
+++ b/test/integration/provider.test.ts
@@ -4,7 +4,7 @@ import { AlchemyProvider } from '@ethersproject/providers';
 
 /**
  * These integrations are sanity checks to ensure that the SDK's overriden
- * implementation of {@link providers.AlchemyProvider} is working as expected.
+ * implementation of {@link AlchemyProvider} is working as expected.
  */
 // TODO(ethers): Figure out appropriate unit tests for the SDK's custom AlchemyProvider.
 describe('AlchemyProvider', () => {


### PR DESCRIPTION
Further reducing bundle size by copying the `Event` class over directly from ethers instead of using the external dependency on `@ethersproject/providers/lib/base-provider`.

Thanks @dphilipson for this realization!

## Results (with only `initializeAlchemy()`)
### Before
![Screen Shot 2022-07-06 at 12 02 02 PM](https://user-images.githubusercontent.com/6948042/177605146-8d2052a6-6299-44af-8b1b-b23ab3bdbb8c.png)

### After
![Screen Shot 2022-07-06 at 12 00 54 PM](https://user-images.githubusercontent.com/6948042/177605170-6d2de8d2-887d-4d06-a458-35b0ec4b0d0f.png)
