### PR TITLE
separate out getProvider and getWebsocketProvider from class

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,5 @@
   "printWidth": 80,
   "trailingComma": "none",
   "arrowParens": "avoid",
-  "plugins": ["prettier-plugin-jsdoc"]
+  "plugins": ["./node_modules/prettier-plugin-jsdoc"]
 }

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -33,12 +33,6 @@ export class Alchemy {
   network: Network;
   readonly maxRetries: number;
 
-  /** @internal */
-  private _baseAlchemyProvider: AlchemyProvider | undefined;
-
-  /** @internal */
-  private _baseAlchemyWssProvider: AlchemyWebSocketProvider | undefined;
-
   /**
    * @hideconstructor
    * @internal
@@ -69,37 +63,41 @@ export class Alchemy {
     // TODO(ethers): Add support for changing the network in the returned provider.
     this.network = network;
   }
-
-  /**
-   * Creates an AlchemyProvider instance. Only one provider is created per
-   * Alchemy instance.
-   *
-   * @public
-   */
-  getProvider(): AlchemyProvider {
-    if (!this._baseAlchemyProvider) {
-      this._baseAlchemyProvider = new AlchemyProvider(
-        this.network,
-        this.apiKey,
-        this.maxRetries
-      );
-    }
-    return this._baseAlchemyProvider;
-  }
-
-  /**
-   * Creates an AlchemyWebsocketProvider instance. Only one provider is created
-   * per Alchemy instance.
-   *
-   * @public
-   */
-  getWebsocketProvider(): AlchemyWebSocketProvider {
-    if (!this._baseAlchemyWssProvider) {
-      this._baseAlchemyWssProvider = new AlchemyWebSocketProvider(
-        this.network,
-        this.apiKey
-      );
-    }
-    return this._baseAlchemyWssProvider;
-  }
 }
+
+/** Creates an AlchemyProvider instance. Only one provider is created per Alchemy instance. */
+export const getProvider: (alchemy: Alchemy) => AlchemyProvider =
+  /*#__PURE__*/ (() => {
+    let _baseAlchemyProvider: AlchemyProvider | undefined;
+    return (alchemy: Alchemy) => {
+      if (!_baseAlchemyProvider) {
+        _baseAlchemyProvider = new AlchemyProvider(
+          alchemy.network,
+          alchemy.apiKey,
+          alchemy.maxRetries
+        );
+      }
+      return _baseAlchemyProvider;
+    };
+  })();
+
+// prettier-ignore
+// Ignoring prettier is required to preserve /*#__PURE__*/ annotation in build.
+/**
+ * Creates an AlchemyWebsocketProvider instance. Only one provider is created
+ * per Alchemy instance.
+ */
+export const getWebsocketProvider: (
+  alchemy: Alchemy
+) => AlchemyWebSocketProvider = (/*#__PURE__*/ (() => {
+  let _baseAlchemyWssProvider: AlchemyWebSocketProvider | undefined;
+  return (alchemy: Alchemy) => {
+    if (!_baseAlchemyWssProvider) {
+      _baseAlchemyWssProvider = new AlchemyWebSocketProvider(
+        alchemy.network,
+        alchemy.apiKey
+      );
+    }
+    return _baseAlchemyWssProvider;
+  };
+})());

--- a/src/api/enhanced.ts
+++ b/src/api/enhanced.ts
@@ -7,7 +7,7 @@ import {
   TransactionReceiptsResponse
 } from '../types/types';
 import { formatBlock } from '../util/util';
-import { Alchemy } from './alchemy';
+import { Alchemy, getProvider } from './alchemy';
 import { DEFAULT_CONTRACT_ADDRESSES } from '../util/const';
 import { toHex } from './util';
 
@@ -22,12 +22,10 @@ export function getTokenBalances(
       'You cannot pass in more than 1500 contract addresses to getTokenBalances()'
     );
   }
-  return alchemy
-    .getProvider()
-    .send('alchemy_getTokenBalances', [
-      address,
-      contractAddresses || DEFAULT_CONTRACT_ADDRESSES
-    ]);
+  return getProvider(alchemy).send('alchemy_getTokenBalances', [
+    address,
+    contractAddresses || DEFAULT_CONTRACT_ADDRESSES
+  ]);
 }
 
 /** @public */
@@ -35,7 +33,7 @@ export function getTokenMetadata(
   alchemy: Alchemy,
   address: string
 ): Promise<TokenMetadataResponse> {
-  return alchemy.getProvider().send('alchemy_getTokenMetadata', [address]);
+  return getProvider(alchemy).send('alchemy_getTokenMetadata', [address]);
 }
 
 /** @public */
@@ -43,7 +41,7 @@ export function getAssetTransfers(
   alchemy: Alchemy,
   params: AssetTransfersParams
 ): Promise<AssetTransfersResponse> {
-  return alchemy.getProvider().send('alchemy_getAssetTransfers', [
+  return getProvider(alchemy).send('alchemy_getAssetTransfers', [
     {
       ...params,
       fromBlock:
@@ -59,5 +57,5 @@ export function getTransactionReceipts(
   alchemy: Alchemy,
   params: TransactionReceiptsParams
 ): Promise<TransactionReceiptsResponse> {
-  return alchemy.getProvider().send('alchemy_getTransactionReceipts', [params]);
+  return getProvider(alchemy).send('alchemy_getTransactionReceipts', [params]);
 }

--- a/src/api/nft-api.ts
+++ b/src/api/nft-api.ts
@@ -15,7 +15,7 @@ import {
   OwnedNft,
   OwnedNftsResponse
 } from '../types/types';
-import { Alchemy } from './alchemy';
+import { Alchemy, getProvider } from './alchemy';
 import { paginateEndpoint, requestHttpWithBackoff } from '../internal/dispatch';
 import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
 import {
@@ -605,7 +605,7 @@ export async function findContractDeployer(
   alchemy: Alchemy,
   contractAddress: string
 ): Promise<DeployResult> {
-  const provider = alchemy.getProvider();
+  const provider = getProvider(alchemy);
   const currentBlockNum = await provider.getBlockNumber();
   if (
     (await provider.getCode(contractAddress, currentBlockNum)) ===
@@ -725,7 +725,7 @@ async function binarySearchFirstBlock(
   }
 
   const mid = Math.floor((start + end) / 2);
-  const code = await alchemy.getProvider().getCode(address, mid);
+  const code = await getProvider(alchemy).getCode(address, mid);
   if (code === ETH_NULL_VALUE) {
     return binarySearchFirstBlock(mid + 1, end, address, alchemy);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 /** This is the main entry point for the library and exports user-facing API. */
 export * from './types/types';
 
-export { initializeAlchemy, Alchemy } from './api/alchemy';
+export {
+  initializeAlchemy,
+  Alchemy,
+  getProvider,
+  getWebsocketProvider
+} from './api/alchemy';
 
 export { AlchemyProvider } from './api/alchemy-provider';
 

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -8,6 +8,7 @@ import {
   getNftsForOwnerIterator,
   getOwnersForCollection,
   getOwnersForNft,
+  getProvider,
   getTokenBalances,
   initializeAlchemy,
   NftExcludeFilters,
@@ -34,7 +35,7 @@ describe('E2E integration tests', () => {
   });
 
   it('test', async () => {
-    console.log(await alchemy.getProvider().getBalance(ownerAddress, 'latest'));
+    console.log(await getProvider(alchemy).getBalance(ownerAddress, 'latest'));
   });
 
   // TODO: add unit test coverage. Integration tests are just sanity tests for now.
@@ -59,7 +60,7 @@ describe('E2E integration tests', () => {
   });
 
   it('getNftMetadata', async () => {
-    console.log(await alchemy.getProvider().getBlockNumber());
+    console.log(await getProvider(alchemy).getBlockNumber());
     const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
     const tokenId = 403;
     const response = await getNftMetadata(

--- a/test/integration/provider.test.ts
+++ b/test/integration/provider.test.ts
@@ -1,4 +1,8 @@
-import { initializeAlchemy } from '../../src';
+import {
+  getProvider,
+  getWebsocketProvider,
+  initializeAlchemy
+} from '../../src';
 import { EthersNetwork } from '../../src/util/const';
 import { AlchemyProvider } from '@ethersproject/providers';
 
@@ -14,8 +18,8 @@ describe('AlchemyProvider', () => {
     alchemy.apiKey
   ) as AlchemyProvider;
 
-  const wsProvider = alchemy.getWebsocketProvider();
-  const provider = alchemy.getProvider();
+  const wsProvider = getWebsocketProvider(alchemy);
+  const provider = getProvider(alchemy);
 
   // TODO(ethers): Extract into helper method to verify all inputs.
   it('methods should return the same result', async () => {

--- a/test/unit/alchemy.test.ts
+++ b/test/unit/alchemy.test.ts
@@ -1,4 +1,9 @@
-import { AlchemyConfig, initializeAlchemy, Network } from '../../src';
+import {
+  AlchemyConfig,
+  getProvider,
+  initializeAlchemy,
+  Network
+} from '../../src';
 import {
   DEFAULT_ALCHEMY_API_KEY,
   DEFAULT_MAX_RETRIES,
@@ -12,7 +17,7 @@ describe('Alchemy class', () => {
         const alchemy = initializeAlchemy({
           network
         });
-        alchemy.getProvider();
+        getProvider(alchemy);
       });
     }
 

--- a/test/unit/websocket-backfiller.test.ts
+++ b/test/unit/websocket-backfiller.test.ts
@@ -1,4 +1,9 @@
-import { fromHex, initializeAlchemy, toHex } from '../../src';
+import {
+  fromHex,
+  getWebsocketProvider,
+  initializeAlchemy,
+  toHex
+} from '../../src';
 import {
   GetLogsOptions,
   WebsocketBackfiller
@@ -31,7 +36,7 @@ describe('Backfill tests', () => {
   }
 
   beforeEach(() => {
-    provider = sdk.getWebsocketProvider() as Mocked<AlchemyWebSocketProvider>;
+    provider = getWebsocketProvider(sdk) as Mocked<AlchemyWebSocketProvider>;
     backfiller = new WebsocketBackfiller(provider);
     provider.send = jest.fn();
     provider.sendBatch = jest.fn();


### PR DESCRIPTION
This is an exploration into providing a more tree-shaking-friendly library. Because `getProvider` and `getWebsocketProvider` are currently methods in the `Alchemy` class, an instantiation of the class will bundle in all of the provider goodies (ethers mostly) even if the consuming application does not use providers (e.g., it's only using the NFT HTTP API).

One solution (given here) is to bring these functions outside of the class. Instead of `alchemy.getProvider()`, it's now `getProvider(alchemy)`. Tested on a CRA that calls just `getNftContractMetadata`, the difference in bundle size is significant:
|Before|After|
|---|---|
|![Screen Shot 2022-07-07 at 2 29 27 AM](https://user-images.githubusercontent.com/8624213/177706827-20957dea-450b-4a4e-a091-dc7f7fbbff89.png)|![Screen Shot 2022-07-07 at 2 28 09 AM](https://user-images.githubusercontent.com/8624213/177706850-a9aa6806-3180-4b97-a3e6-436b7e835e95.png)|

Note that there exists a bug in that if `getProvider` was called once, and subsequently a new `Alchemy` instance is passed in or if `setNetwork` was called on the existing instance, the same old provider instance will be returned. This actually replicates the existing behavior as it is today. I didn't want to make too many changes outside the core change here, so that'll be addressed in a later PR if we decide to move forward with this.