### PR TITLE
Moving all NFT methods into top-level `alchemy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,28 +28,15 @@ const settings = {
 const alchemy = initializeAlchemy(settings);
 ```
 
-The SDK's modular approach exports all Alchemy functions at the top-level to reduce bundle size (only the functions you
-import
-and use will be included). This means you access each method using the following pattern:
+You can access each method using the following pattern:
 
 ```ts
 // Initializing the alchemy config object
-import { initializeAlchemy, getNftsForOwner } from '@alch/alchemy-sdk';
+import { initializeAlchemy } from '@alch/alchemy-sdk';
 
 const alchemy = initializeAlchemy(); // using default settings - pass in a settings object to specify your API key and network
 
-getNftsForOwner(alchemy, '0xshah.eth').then(console.log);
-```
-
-However, this can make it harder to discover the full API surface. If you want your IDE to find all functions, you can
-alternatively import
-the entire SDK (though this is not recommended, as it will increase the bundle size):
-
-```ts
-import * as alchemySdk from '@alch/alchemy-sdk';
-
-const alchemy = alchemySdk.initializeAlchemy();
-alchemySdk.getNftsForOwner(alchemy, '0xshah.eth').then(console.log);
+alchemy.getNftsForOwner('0xshah.eth').then(console.log);
 ```
 
 ### Preventing Breaking Changes
@@ -64,13 +51,14 @@ For example, to pin to a specific version of the SDK in your `package.json` file
 ```
 {
   "dependencies": {
-    "@alch/alchemy-sdk": "1.0.4"
+    "@alch/alchemy-sdk": "1.1.0"
   }
 }
 ```
 
 ## SDK Structure
 
+#### TODO: UPDATE THIS SECTION AFTER FULL MIGRATION
 The `Alchemy` object returned by `initializeAlchemy()` provides access to the Alchemy API. An optional config
 object can be passed in when initializing to set your API key, change the network, or specify the max number of retries.
 
@@ -160,7 +148,8 @@ right. `alchemy-sdk` automatically handles these failures with no configuration 
 
 ## NFT Module
 
-The SDK currently supports the following [NFT API](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api) endpoints:
+The SDK currently supports the following [NFT API](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api) endpoints
+under the `Alchemy` class:
 
 - `getNftMetadata()`: Get the NFT metadata for a contract address and tokenId.
 - `getNftContractMetadata()`: Get the metadata associated with an NFT contract
@@ -200,13 +189,13 @@ an `AsyncIterable`.
 Here's an example of how to paginate through all the NFTs in Vitalik's ENS address:
 
 ```ts
-import { initializeAlchemy, getNftsForOwnerIterator } from '@alch/alchemy-sdk';
+import { initializeAlchemy } from '@alch/alchemy-sdk';
 
 const alchemy = initializeAlchemy();
 
 async function main() {
   const ownerAddress = 'vitalik.eth';
-  for await (const nft of getNftsForOwnerIterator(alchemy, ownerAddress)) {
+  for await (const nft of alchemy.getNftsForOwnerIterator(ownerAddress)) {
     console.log('ownedNft:', nft);
   }
 }
@@ -250,8 +239,6 @@ Getting the NFTs owned by an address.
 
 ```ts
 import {
-  getNftsForOwner,
-  getNftsForOwnerIterator,
   NftExcludeFilters,
   initializeAlchemy
 } from '@alch/alchemy-sdk';
@@ -259,13 +246,13 @@ import {
 const alchemy = initializeAlchemy();
 
 // Get how many NFTs an address owns.
-getNftsForOwner(alchemy, '0xshah.eth').then(nfts => {
+alchemy.getNftsForOwner('0xshah.eth').then(nfts => {
   console.log(nfts.totalCount);
 });
 
 // Get all the image urls for all the NFTs an address owns.
 async function main() {
-  for await (const nft of getNftsForOwnerIterator(alchemy, '0xshah.eth')) {
+  for await (const nft of alchemy.getNftsForOwnerIterator('0xshah.eth')) {
     console.log(nft.media);
   }
 }
@@ -273,7 +260,7 @@ async function main() {
 main();
 
 // Filter out spam NFTs.
-getNftsForOwner(alchemy, '0xshah.eth', {
+alchemy.getNftsForOwner('0xshah.eth', {
   excludeFilters: [NftExcludeFilters.SPAM]
 }).then(console.log);
 ```
@@ -282,8 +269,6 @@ Getting all the owners of the BAYC NFT.
 
 ```ts
 import {
-  getOwnersForNft,
-  getNftsForCollectionIterator,
   initializeAlchemy
 } from '@alch/alchemy-sdk';
 
@@ -293,11 +278,11 @@ const alchemy = initializeAlchemy();
 const baycAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
 
 async function main() {
-  for await (const nft of getNftsForCollectionIterator(alchemy, baycAddress, {
+  for await (const nft of alchemy.getNftsForCollectionIterator(baycAddress, {
     // Omit the NFT metadata for smaller payloads.
     omitMetadata: true
   })) {
-    await getOwnersForNft(alchemy, nft).then(response =>
+    await alchemy.getOwnersForNft(nft).then(response =>
       console.log('owners:', response.owners, 'tokenId:', nft.tokenId)
     );
   }
@@ -309,11 +294,11 @@ main();
 Get all outbound transfers for a provided address.
 
 ```ts
-import { getTokenBalances, initializeAlchemy } from '@alch/alchemy-sdk';
+import { initializeAlchemy } from '@alch/alchemy-sdk';
 
 const alchemy = initializeAlchemy();
 
-getTokenBalances(alchemy, '0x994b342dd87fc825f66e51ffa3ef71ad818b6893').then(
+alchemy.getTokenBalances('0x994b342dd87fc825f66e51ffa3ef71ad818b6893').then(
   console.log
 );
 ```

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -1,4 +1,22 @@
-import { AlchemyConfig, Network } from '../types/types';
+import {
+  AlchemyConfig,
+  DeployResult,
+  GetBaseNftsForNftContractOptions,
+  GetBaseNftsForOwnerOptions,
+  GetNftFloorPriceResponse,
+  GetNftsForNftContractOptions,
+  GetNftsForOwnerOptions,
+  GetOwnersForNftContractResponse,
+  GetOwnersForNftResponse,
+  Network,
+  NftContractBaseNftsResponse,
+  NftContractNftsResponse,
+  NftTokenType,
+  OwnedBaseNft,
+  OwnedBaseNftsResponse,
+  OwnedNft,
+  OwnedNftsResponse
+} from '../types/types';
 import {
   DEFAULT_ALCHEMY_API_KEY,
   DEFAULT_MAX_RETRIES,
@@ -8,6 +26,24 @@ import {
 } from '../util/const';
 import type { AlchemyWebSocketProvider } from './alchemy-websocket-provider';
 import type { AlchemyProvider } from './alchemy-provider';
+import { BigNumberish } from '@ethersproject/bignumber';
+import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
+import {
+  getNftContractMetadata,
+  getNftsForOwnerIterator,
+  getNftMetadata,
+  getNftsForOwner,
+  getNftsForNftContract,
+  getOwnersForNftContract,
+  getOwnersForNft,
+  getNftsForNftContractIterator,
+  checkNftOwnership,
+  isSpamNftContract,
+  getSpamNftContracts,
+  getNftFloorPrice,
+  findContractDeployer,
+  refreshNftMetadata
+} from '../internal/nft-api';
 
 /**
  * Entry point into the Alchemy SDK.
@@ -50,13 +86,354 @@ export class Alchemy {
   }
 
   /** @internal */
-  getBaseUrl(): string {
+  _getBaseUrl(): string {
     return getAlchemyHttpUrl(this.network, this.apiKey);
   }
 
   /** @internal */
-  getNftUrl(): string {
+  _getNftUrl(): string {
     return getAlchemyNftHttpUrl(this.network, this.apiKey);
+  }
+
+  /**
+   * Get the NFT metadata associated with the provided parameters.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @param tokenId - Token id of the NFT.
+   * @param tokenType - Optionally specify the type of token to speed up the query.
+   * @public
+   */
+  getNftMetadata(
+    contractAddress: string,
+    tokenId: BigNumberish,
+    tokenType?: NftTokenType
+  ): Promise<Nft>;
+  /**
+   * Get the NFT metadata associated with the provided Base NFT.
+   *
+   * @param baseNft - The base NFT object to be used for the request.
+   * @public
+   */
+  getNftMetadata(baseNft: BaseNft): Promise<Nft>;
+  getNftMetadata(
+    contractAddressOrBaseNft: string | BaseNft,
+    tokenId?: BigNumberish,
+    tokenType?: NftTokenType
+  ): Promise<Nft> {
+    return getNftMetadata(this, contractAddressOrBaseNft, tokenId, tokenType);
+  }
+
+  /**
+   * Get the NFT collection metadata associated with the provided parameters.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @public
+   */
+  getNftContractMetadata(contractAddress: string): Promise<NftContract>;
+  /**
+   * Get the NFT metadata associated with the provided Base NFT.
+   *
+   * @param baseNftContract - The base NFT contract object to be used for the request.
+   * @public
+   */
+  getNftContractMetadata(
+    baseNftContract: BaseNftContract
+  ): Promise<NftContract>;
+  getNftContractMetadata(
+    contractAddressOrBaseNftContract: string | BaseNftContract
+  ): Promise<NftContract> {
+    return getNftContractMetadata(this, contractAddressOrBaseNftContract);
+  }
+
+  /**
+   * Fetches all NFTs for a given owner and yields them in an async iterable.
+   *
+   * This method returns the full NFT for the owner and pages through all page
+   * keys until all NFTs have been fetched.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetNftsForOwnerOptions
+  ): AsyncIterable<OwnedNft>;
+  /**
+   * Fetches all NFTs for a given owner and yields them in an async iterable.
+   *
+   * This method returns the base NFTs that omit the associated metadata and
+   * pages through all page keys until all NFTs have been fetched.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetBaseNftsForOwnerOptions
+  ): AsyncIterable<OwnedBaseNft>;
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
+  ): AsyncIterable<OwnedBaseNft | OwnedNft> {
+    return getNftsForOwnerIterator(this, owner, options);
+  }
+
+  /**
+   * Get all NFTs for an owner.
+   *
+   * This method returns the full NFTs in the contract. To get all NFTs without
+   * their associated metadata, use {@link GetBaseNftsForOwnerOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwner(
+    owner: string,
+    options?: GetNftsForOwnerOptions
+  ): Promise<OwnedNftsResponse>;
+  /**
+   * Get all base NFTs for an owner.
+   *
+   * This method returns the base NFTs that omit the associated metadata. To get
+   * all NFTs with their associated metadata, use {@link GetNftsForOwnerOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwner(
+    owner: string,
+    options?: GetBaseNftsForOwnerOptions
+  ): Promise<OwnedBaseNftsResponse>;
+  getNftsForOwner(
+    owner: string,
+    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
+  ): Promise<OwnedNftsResponse | OwnedBaseNftsResponse> {
+    return getNftsForOwner(this, owner, options);
+  }
+
+  /**
+   * Get all NFTs for a given contract address.
+   *
+   * This method returns the full NFTs in the contract. To get all NFTs without
+   * their associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The parameters to use for the request. or
+   *   {@link NftContractNftsResponse} response.
+   * @beta
+   */
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetNftsForNftContractOptions
+  ): Promise<NftContractNftsResponse>;
+  /**
+   * Get all base NFTs for a given contract address.
+   *
+   * This method returns the base NFTs that omit the associated metadata. To get
+   * all NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions
+  ): Promise<NftContractBaseNftsResponse>;
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  ): Promise<NftContractNftsResponse | NftContractBaseNftsResponse> {
+    return getNftsForNftContract(this, contractAddress, options);
+  }
+
+  /**
+   * Fetches all NFTs for a given contract address and yields them in an async iterable.
+   *
+   * This method returns the full NFTs in the contract and pages through all
+   * page keys until all NFTs have been fetched. To get all NFTs without their
+   * associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetNftsForNftContractOptions
+  ): AsyncIterable<Nft>;
+  /**
+   * Fetches all base NFTs for a given contract address and yields them in an
+   * async iterable.
+   *
+   * This method returns the base NFTs that omit the associated metadata and
+   * pages through all page keys until all NFTs have been fetched. To get all
+   * NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions
+  ): AsyncIterable<BaseNft>;
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  ): AsyncIterable<BaseNft | Nft> {
+    return getNftsForNftContractIterator(this, contractAddress, options);
+  }
+
+  /**
+   * Gets all the owners for a given NFT contract.
+   *
+   * @param contractAddress - The NFT contract to get the owners for.
+   * @beta
+   */
+  getOwnersForNftContract(
+    contractAddress: string
+  ): Promise<GetOwnersForNftContractResponse>;
+  /**
+   * Gets all the owners for a given NFT contract.
+   *
+   * @param nft - The NFT to get the owners of the NFT contract for.
+   * @beta
+   */
+  getOwnersForNftContract(
+    nft: BaseNft
+  ): Promise<GetOwnersForNftContractResponse>;
+  getOwnersForNftContract(
+    contractAddressOrNft: string | BaseNft
+  ): Promise<GetOwnersForNftContractResponse> {
+    return getOwnersForNftContract(this, contractAddressOrNft);
+  }
+
+  /**
+   * Gets all the owners for a given NFT contract address and token ID.
+   *
+   * @param contractAddress - The NFT contract address.
+   * @param tokenId - Token id of the NFT.
+   * @beta
+   */
+  getOwnersForNft(
+    contractAddress: string,
+    tokenId: BigNumberish
+  ): Promise<GetOwnersForNftResponse>;
+  /**
+   * Gets all the owners for a given NFT.
+   *
+   * @param nft - The NFT object to get the owners for.
+   * @beta
+   */
+  getOwnersForNft(nft: BaseNft): Promise<GetOwnersForNftResponse>;
+  getOwnersForNft(
+    contractAddressOrNft: string | BaseNft,
+    tokenId?: BigNumberish
+  ): Promise<GetOwnersForNftResponse> {
+    return getOwnersForNft(this, contractAddressOrNft, tokenId);
+  }
+
+  /**
+   * Checks that the provided owner address owns one of more of the provided NFTs.
+   *
+   * @param owner - The owner address to check.
+   * @param contractAddresses - An array of NFT contract addresses to check ownership for.
+   * @beta
+   */
+  checkNftOwnership(
+    owner: string,
+    contractAddresses: string[]
+  ): Promise<boolean> {
+    return checkNftOwnership(this, owner, contractAddresses);
+  }
+
+  /**
+   * Returns whether a contract is marked as spam or not by Alchemy. For more
+   * information on how we classify spam, go to our NFT API FAQ at
+   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
+   *
+   * @param contractAddress - The contract address to check.
+   * @beta
+   */
+  isSpamNftContract(contractAddress: string): Promise<boolean> {
+    return isSpamNftContract(this, contractAddress);
+  }
+
+  /**
+   * Returns a list of all spam contracts marked by Alchemy. For details on how
+   * Alchemy marks spam contracts, go to
+   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
+   *
+   * @beta
+   */
+  getSpamNftContracts(): Promise<string[]> {
+    return getSpamNftContracts(this);
+  }
+
+  /**
+   * Returns the floor prices of a NFT contract by marketplace.
+   *
+   * @param contractAddress - The contract address for the NFT collection.
+   * @beta
+   */
+  getNftFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
+    return getNftFloorPrice(this, contractAddress);
+  }
+
+  /**
+   * Finds the address that deployed the provided contract and block number it
+   * was deployed in.
+   *
+   * NOTE: This method performs a binary search across all blocks since genesis
+   * and can take a long time to complete. This method is a convenience method
+   * that will eventually be replaced by a single call to an Alchemy endpoint
+   * with this information cached.
+   *
+   * @param contractAddress - The contract address to find the deployer for.
+   * @beta
+   */
+  findContractDeployer(contractAddress: string): Promise<DeployResult> {
+    return findContractDeployer(this, contractAddress);
+  }
+
+  /**
+   * Refreshes the cached metadata for a provided NFT contract address and token
+   * id. Returns a boolean value indicating whether the metadata was refreshed.
+   *
+   * This method is useful when you want to refresh the metadata for a NFT that
+   * has been updated since the last time it was fetched. Note that the backend
+   * only allows one refresh per token every 15 minutes, globally for all users.
+   * The last refresh time for an NFT can be accessed on the
+   * {@link Nft.timeLastUpdated} field.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @param tokenId - The token id of the NFT.
+   */
+  refreshNftMetadata(
+    contractAddress: string,
+    tokenId: BigNumberish
+  ): Promise<boolean>;
+  /**
+   * Refreshes the cached metadata for a provided NFT contract address and token
+   * id. Returns a boolean value indicating whether the metadata was refreshed.
+   *
+   * This method is useful when you want to refresh the metadata for a NFT that
+   * has been updated since the last time it was fetched. Note that the backend
+   * only allows one refresh per token every 15 minutes, globally for all users.
+   *
+   * @param nft - The NFT to refresh the metadata for.
+   */
+  refreshNftMetadata(nft: BaseNft): Promise<boolean>;
+  refreshNftMetadata(
+    contractAddressOrBaseNft: string | BaseNft,
+    tokenId?: BigNumberish
+  ): Promise<boolean> {
+    return refreshNftMetadata(this, contractAddressOrBaseNft, tokenId);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,23 +4,6 @@ export * from './types/types';
 export { initializeAlchemy, Alchemy } from './api/alchemy';
 
 export {
-  getNftMetadata,
-  getNftContractMetadata,
-  getNftsForOwner,
-  getNftsForOwnerIterator,
-  getNftsForNftContract,
-  getNftsForNftContractIterator,
-  getOwnersForNft,
-  getOwnersForNftContract,
-  checkNftOwnership,
-  isSpamNftContract,
-  getSpamNftContracts,
-  getNftFloorPrice,
-  findContractDeployer,
-  refreshNftMetadata
-} from './api/nft-api';
-
-export {
   getTransactionReceipts,
   getAssetTransfers,
   getTokenMetadata,

--- a/src/internal/dispatch.ts
+++ b/src/internal/dispatch.ts
@@ -40,7 +40,7 @@ export async function requestHttpWithBackoff<Req, Res>(
       switch (apiType) {
         case AlchemyApiType.NFT:
           response = await sendAxiosRequest<Req, Res>(
-            alchemy.getNftUrl(),
+            alchemy._getNftUrl(),
             method,
             params
           );
@@ -48,7 +48,7 @@ export async function requestHttpWithBackoff<Req, Res>(
         default:
         case AlchemyApiType.BASE:
           response = await sendAxiosRequest<Req, Res>(
-            alchemy.getBaseUrl(),
+            alchemy._getBaseUrl(),
             method,
             params
           );


### PR DESCRIPTION
This PR removes the top-level NFT API methods and moves them into the `Alchemy` class. Pulling in all of the NFT code grows our SDK's code from 6kB to 12kB, which is definitely ok compared to the 43kB from the BN package used by ethers.

List of changes:
- prefixed internal methods with `_` on `Alchemy` class for JS builds
- moved core NFT API logic into `src/internal` to keep `Alchemy` class clean