### PR TITLE
Add refreshNftContract() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ under the `Alchemy` class:
 - `isSpamNftContract()`: Check whether the given NFT contract address is a spam contract as defined by Alchemy (see the [NFT API FAQ](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification))
 - `getSpamNftContracts()`: Returns a list of all spam contracts marked by Alchemy.
 - `findContractDeployer()`: Find the contract deployer and block number for a given NFT contract address.
-- `refreshNftMetadata()`: Refresh the cached NFT metadata for a contract address and tokenId.
-- `getNftFloorPrice()`: Returns the floor prices of a NFT contract by marketplace.
+- `refreshNftMetadata()`: Refresh the cached NFT metadata for a contract address and a single tokenId.
+- `refreshNftContract()`: Refresh the cached metadata for all tokens in the specified contract address. 
+- `getNftFloorPrice()`: Return the floor prices of a NFT contract by marketplace.
 
 ### Comparing `BaseNft` and `Nft`
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ under the `Alchemy` class:
 - `getSpamNftContracts()`: Returns a list of all spam contracts marked by Alchemy.
 - `findContractDeployer()`: Find the contract deployer and block number for a given NFT contract address.
 - `refreshNftMetadata()`: Refresh the cached NFT metadata for a contract address and a single tokenId.
-- `refreshNftContract()`: Refresh the cached metadata for all tokens in the specified contract address. 
+- `refreshNftContract()`: Enqueues the specified contract address to have all token ids' metadata refreshed. 
 - `getNftFloorPrice()`: Return the floor prices of a NFT contract by marketplace.
 
 ### Comparing `BaseNft` and `Nft`

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -19,6 +19,7 @@ import {
   OwnedBaseNftsResponse,
   OwnedNft,
   OwnedNftsResponse,
+  RefreshNftContractResult,
   TokenBalancesResponse,
   TokenMetadataResponse,
   TransactionReceiptsParams,
@@ -49,7 +50,8 @@ import {
   getSpamNftContracts,
   getNftFloorPrice,
   findContractDeployer,
-  refreshNftMetadata
+  refreshNftMetadata,
+  refreshNftContract
 } from '../internal/nft-api';
 import { formatBlock } from '../util/util';
 import { toHex } from './util';
@@ -429,6 +431,9 @@ export class Alchemy {
    * The last refresh time for an NFT can be accessed on the
    * {@link Nft.timeLastUpdated} field.
    *
+   * To trigger a refresh for all NFTs in a contract, use
+   * {@link refreshNftContract} instead.
+   *
    * @param contractAddress - The contract address of the NFT.
    * @param tokenId - The token id of the NFT.
    */
@@ -444,6 +449,9 @@ export class Alchemy {
    * has been updated since the last time it was fetched. Note that the backend
    * only allows one refresh per token every 15 minutes, globally for all users.
    *
+   * To trigger a refresh for all NFTs in a contract, use
+   * {@link refreshNftContract} instead.
+   *
    * @param nft - The NFT to refresh the metadata for.
    */
   refreshNftMetadata(nft: BaseNft): Promise<boolean>;
@@ -452,6 +460,38 @@ export class Alchemy {
     tokenId?: BigNumberish
   ): Promise<boolean> {
     return refreshNftMetadata(this, contractAddressOrBaseNft, tokenId);
+  }
+
+  /**
+   * Triggers a metadata refresh all NFTs in the provided contract address. This
+   * method is useful after an NFT collection is revealed.
+   *
+   * Refreshes are queued on the Alchemy backend and may take time to fully
+   * process. To refresh the metadata for a specific token, use the
+   * {@link refreshNftMetadata} method instead.
+   *
+   * @param contractAddress - The contract address of the NFT collection.
+   * @beta
+   */
+  refreshNftContract(
+    contractAddress: string
+  ): Promise<RefreshNftContractResult>;
+  /**
+   * Triggers a metadata refresh all NFTs in the provided contract address. This
+   * method is useful after an NFT collection is revealed.
+   *
+   * Refreshes are queued on the Alchemy backend and may take time to fully
+   * process. To refresh the metadata for a specific token, use the
+   * {@link refreshNftMetadata} method instead.
+   *
+   * @param nft - The contract address of the NFT collection.
+   * @beta
+   */
+  refreshNftContract(nft: BaseNft): Promise<RefreshNftContractResult>;
+  refreshNftContract(
+    contractAddressOrBaseNft: string | BaseNft
+  ): Promise<RefreshNftContractResult> {
+    return refreshNftContract(this, contractAddressOrBaseNft);
   }
 
   /**

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -165,3 +165,9 @@ export interface RawNftContractNft extends RawNft, RawNftContractBaseNft {}
 export interface RawGetOwnersForNftContractResponse {
   ownerAddresses: string[];
 }
+
+export interface RawReingestContractResponse {
+  contractAddress: string;
+  reingestionState: string;
+  progress: string | null;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -406,6 +406,42 @@ export interface GetNftFloorPriceResponse {
   readonly looksRare: FloorPriceMarketplace | FloorPriceError;
 }
 
+/** The refresh result response object returned by {@link refreshNftContract}. */
+export interface RefreshNftContractResult {
+  /** The NFT contract address that was passed in to be refreshed. */
+  contractAddress: string;
+
+  /** The current state of the refresh request. */
+  refreshState: RefreshState;
+
+  /**
+   * Percentage of tokens currently refreshed, represented as an integer string.
+   * Field can be null if the refresh has not occurred.
+   */
+  progress: string | null;
+}
+
+/** The current state of the NFT contract refresh process. */
+export enum RefreshState {
+  /** The provided contract is not an NFT or does not contain metadata. */
+  DOES_NOT_EXIST = 'does_not_exist',
+
+  /** The contract has already been queued for refresh. */
+  ALREADY_QUEUED = 'already_queued',
+
+  /** The contract is currently being refreshed. */
+  IN_PROGRESS = 'in_progress',
+
+  /** The contract refresh is complete. */
+  FINISHED = 'finished',
+
+  /** The contract refresh has been queued and await execution. */
+  QUEUED = 'queued',
+
+  /** The contract was unable to be queued due to an internal error. */
+  QUEUE_FAILED = 'queue_failed'
+}
+
 /** @public */
 export interface TransactionReceiptsBlockNumber {
   blockNumber: string;

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -167,6 +167,12 @@ describe('E2E integration tests', () => {
     await alchemy.refreshNftMetadata(nft);
   });
 
+  it('refreshNftContract()', async () => {
+    const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
+    const result = await alchemy.refreshNftContract(contractAddress);
+    console.log('result', result);
+  });
+
   describe('README examples', () => {
     it('Example 1: Getting the Nfts owned by an address', async () => {
       void alchemy.getNftsForOwner('0xshah.eth').then(nfts => {


### PR DESCRIPTION
Adds the endpoint for `reingestContract`. Decided to rename to `refreshNftContract()` in order to match `refreshNftMetadata()`. 