### PR TITLE
Create separate submodule for NFT methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alchemy SDK for Javascript
 
-Alchemy SDK helps developers use Alchemy's APIs and endpoints more efficiently. This is a lightweight, modular SDK built as a drop-in replacement of Ethers.js that provides a superset of functionality - enabling access to the Alchemy NFT API, Websockets, and Enhanced API methods. 
+Alchemy SDK helps developers use Alchemy's APIs and endpoints more efficiently. This is a lightweight, modular SDK built as a drop-in replacement of Ethers.js that provides a superset of functionality - enabling access to the Alchemy NFT API, Websockets, and Enhanced API methods.
 
 It also provides access to Alchemy's hardened node infrastructure, guaranteeing reliability, scalability, and quality-of-life improvements such as automatic exponential backoff retries.
 
@@ -27,7 +27,8 @@ const settings = {
 const alchemy = new Alchemy(settings);
 ```
 
-You can access each method using the following pattern. Methods supported include: 
+You can access each method using the following pattern. Methods supported include:
+
 - All commonly-used Ethers.js methods
 - Alchemy NFT API methods
 - Alchemy Enhanced API methods
@@ -39,7 +40,7 @@ If you are already using Ethers.js, you should be simply able to replace the Eth
 import { Alchemy } from '@alch/alchemy-sdk';
 
 // Using default settings - pass in a settings object to specify your API key and network
-const alchemy = new Alchemy(); 
+const alchemy = new Alchemy();
 
 // Access standard Ethers.js JSON-RPC node requests
 alchemy.getBlockNumber().then(console.log);
@@ -148,21 +149,21 @@ The SDK currently supports the following [NFT API](https://docs.alchemy.com/alch
 under the `Alchemy` class:
 
 - `getNftMetadata()`: Get the NFT metadata for a contract address and tokenId.
-- `getNftContractMetadata()`: Get the metadata associated with an NFT contract
+- `getContractMetadata()`: Get the metadata associated with an NFT contract
 - `getNftsForOwner()`: Get NFTs for an owner address.
 - `getNftsForOwnerIterator()`: Get NFTs for an owner address as an async iterator (handles paging automatically).
-- `getNftsForNftContract()`: Get all NFTs for a contract address.
-- `getNftForNftContractIterator()`: Get all NFTs for a contract address as an async iterator (handles paging
+- `getNftsForContract()`: Get all NFTs for a contract address.
+- `getNftForContractIterator()`: Get all NFTs for a contract address as an async iterator (handles paging
   automatically).
 - `getOwnersForNft()`: Get all the owners for a given NFT contract address and a particular token ID.
-- `getOwnersForNftContract()`: Get all the owners for a given NFT contract address.
+- `getOwnersForContract()`: Get all the owners for a given NFT contract address.
 - `checkNftOwnership()`: Check that the provided owner address owns one or more of the provided NFT contract addresses.
-- `isSpamNftContract()`: Check whether the given NFT contract address is a spam contract as defined by Alchemy (see the [NFT API FAQ](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification))
-- `getSpamNftContracts()`: Returns a list of all spam contracts marked by Alchemy.
+- `isSpamContract()`: Check whether the given NFT contract address is a spam contract as defined by Alchemy (see the [NFT API FAQ](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification))
+- `getSpamContracts()`: Returns a list of all spam contracts marked by Alchemy.
 - `findContractDeployer()`: Find the contract deployer and block number for a given NFT contract address.
 - `refreshNftMetadata()`: Refresh the cached NFT metadata for a contract address and a single tokenId.
-- `refreshNftContract()`: Enqueues the specified contract address to have all token ids' metadata refreshed. 
-- `getNftFloorPrice()`: Return the floor prices of a NFT contract by marketplace.
+- `refreshContract()`: Enqueues the specified contract address to have all token ids' metadata refreshed.
+- `getFloorPrice()`: Return the floor prices of a NFT contract by marketplace.
 
 ### Comparing `BaseNft` and `Nft`
 
@@ -205,7 +206,7 @@ main();
 The NFT API in the SDK standardizes response types to reduce developer friction, but note this results in some
 differences compared to the Alchemy REST endpoints:
 
-- Methods referencing `Collection` have been renamed to use the name `NftContract` for greater accuracy: e.g. `getNftsForNftContract`.
+- Methods referencing `Collection` have been renamed to use the name `Contract` for greater accuracy: e.g. `getNftsForContract`.
 - Some methods have different naming that the REST API counterparts in order to provide a consistent API interface (
   e.g. `getNftsForOwner()` is `alchemy_getNfts`, `getOwnersForNft()` is `alchemy_getOwnersForToken`).
 - SDK standardizes to `omitMetadata` parameter (vs. `withMetadata`).
@@ -236,21 +237,18 @@ Below are a few usage examples:
 Getting the NFTs owned by an address.
 
 ```ts
-import {
-  NftExcludeFilters,
-  Alchemy
-} from '@alch/alchemy-sdk';
+import { NftExcludeFilters, Alchemy } from '@alch/alchemy-sdk';
 
 const alchemy = new Alchemy();
 
 // Get how many NFTs an address owns.
-alchemy.getNftsForOwner('0xshah.eth').then(nfts => {
+alchemy.nft.getNftsForOwner('0xshah.eth').then(nfts => {
   console.log(nfts.totalCount);
 });
 
 // Get all the image urls for all the NFTs an address owns.
 async function main() {
-  for await (const nft of alchemy.getNftsForOwnerIterator('0xshah.eth')) {
+  for await (const nft of alchem.nft.getNftsForOwnerIterator('0xshah.eth')) {
     console.log(nft.media);
   }
 }
@@ -258,17 +256,17 @@ async function main() {
 main();
 
 // Filter out spam NFTs.
-alchemy.getNftsForOwner('0xshah.eth', {
-  excludeFilters: [NftExcludeFilters.SPAM]
-}).then(console.log);
+alchemy.nft
+  .getNftsForOwner('0xshah.eth', {
+    excludeFilters: [NftExcludeFilters.SPAM]
+  })
+  .then(console.log);
 ```
 
 Getting all the owners of the BAYC NFT.
 
 ```ts
-import {
-  Alchemy
-} from '@alch/alchemy-sdk';
+import { Alchemy } from '@alch/alchemy-sdk';
 
 const alchemy = new Alchemy();
 
@@ -276,13 +274,18 @@ const alchemy = new Alchemy();
 const baycAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
 
 async function main() {
-  for await (const nft of alchemy.getNftsForNftContractIterator(baycAddress, {
-    // Omit the NFT metadata for smaller payloads.
-    omitMetadata: true
-  })) {
-    await alchemy.getOwnersForNft(nft).then(response =>
-      console.log('owners:', response.owners, 'tokenId:', nft.tokenId)
-    );
+  for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+    baycAddress,
+    {
+      // Omit the NFT metadata for smaller payloads.
+      omitMetadata: true
+    }
+  )) {
+    await alchemy.nft
+      .getOwnersForNft(nft)
+      .then(response =>
+        console.log('owners:', response.owners, 'tokenId:', nft.tokenId)
+      );
   }
 }
 
@@ -296,9 +299,9 @@ import { Alchemy } from '@alch/alchemy-sdk';
 
 const alchemy = new Alchemy();
 
-alchemy.getTokenBalances('0x994b342dd87fc825f66e51ffa3ef71ad818b6893').then(
-  console.log
-);
+alchemy
+  .getTokenBalances('0x994b342dd87fc825f66e51ffa3ef71ad818b6893')
+  .then(console.log);
 ```
 
 ## Questions and Feedback

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ alchemy.nft.getNftsForOwner('0xshah.eth').then(nfts => {
 
 // Get all the image urls for all the NFTs an address owns.
 async function main() {
-  for await (const nft of alchem.nft.getNftsForOwnerIterator('0xshah.eth')) {
+  for await (const nft of alchemy.nft.getNftsForOwnerIterator('0xshah.eth')) {
     console.log(nft.media);
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,20 +7,20 @@ const allBuilds = {
   input: 'src/index.ts',
   output: [
     {
-      dir: "dist/cjs",
+      dir: 'dist/cjs',
       format: 'cjs',
       sourcemap: true
     },
     {
-      dir: "dist/esm",
+      dir: 'dist/esm',
       format: 'esm',
       sourcemap: true
     },
     {
-      dir: "dist/es",
+      dir: 'dist/es',
       format: 'es',
       sourcemap: true
-    },
+    }
   ],
   external: [...Object.keys(pkg.dependencies || {})],
   plugins: [typescriptPlugin(), nodeResolve(), commonjs()]

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -4,22 +4,7 @@ import {
   AssetTransfersParams,
   AssetTransfersResponse,
   DeployResult,
-  GetBaseNftsForNftContractOptions,
-  GetBaseNftsForOwnerOptions,
-  GetNftFloorPriceResponse,
-  GetNftsForNftContractOptions,
-  GetNftsForOwnerOptions,
-  GetOwnersForNftContractResponse,
-  GetOwnersForNftResponse,
   Network,
-  NftContractBaseNftsResponse,
-  NftContractNftsResponse,
-  NftTokenType,
-  OwnedBaseNft,
-  OwnedBaseNftsResponse,
-  OwnedNft,
-  OwnedNftsResponse,
-  RefreshNftContractResult,
   TokenBalancesResponse,
   TokenMetadataResponse,
   TransactionReceiptsParams,
@@ -35,24 +20,7 @@ import {
 } from '../util/const';
 import type { AlchemyWebSocketProvider } from './alchemy-websocket-provider';
 import type { AlchemyProvider } from './alchemy-provider';
-import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
-import {
-  getNftContractMetadata,
-  getNftsForOwnerIterator,
-  getNftMetadata,
-  getNftsForOwner,
-  getNftsForNftContract,
-  getOwnersForNftContract,
-  getOwnersForNft,
-  getNftsForNftContractIterator,
-  checkNftOwnership,
-  isSpamNftContract,
-  getSpamNftContracts,
-  getNftFloorPrice,
-  findContractDeployer,
-  refreshNftMetadata,
-  refreshNftContract
-} from '../internal/nft-api';
+import { findContractDeployer } from '../internal/nft-api';
 import { formatBlock } from '../util/util';
 import { toHex } from './util';
 import type { BigNumber, BigNumberish } from '@ethersproject/bignumber';
@@ -73,6 +41,7 @@ import {
   FilterByBlockHash,
   Log
 } from '@ethersproject/abstract-provider';
+import { NftModule } from './nft-module';
 
 /**
  * The Alchemy SDK client. This class holds config information and provides
@@ -105,6 +74,10 @@ export class Alchemy {
     this.maxRetries = config?.maxRetries || DEFAULT_MAX_RETRIES;
   }
 
+  get nft(): NftModule {
+    return new NftModule(this);
+  }
+
   /** @internal */
   _getBaseUrl(): string {
     return getAlchemyHttpUrl(this.network, this.apiKey);
@@ -113,296 +86,6 @@ export class Alchemy {
   /** @internal */
   _getNftUrl(): string {
     return getAlchemyNftHttpUrl(this.network, this.apiKey);
-  }
-
-  /**
-   * Get the NFT metadata associated with the provided parameters.
-   *
-   * @param contractAddress - The contract address of the NFT.
-   * @param tokenId - Token id of the NFT.
-   * @param tokenType - Optionally specify the type of token to speed up the query.
-   * @public
-   */
-  getNftMetadata(
-    contractAddress: string,
-    tokenId: BigNumberish,
-    tokenType?: NftTokenType
-  ): Promise<Nft>;
-  /**
-   * Get the NFT metadata associated with the provided Base NFT.
-   *
-   * @param baseNft - The base NFT object to be used for the request.
-   * @public
-   */
-  getNftMetadata(baseNft: BaseNft): Promise<Nft>;
-  getNftMetadata(
-    contractAddressOrBaseNft: string | BaseNft,
-    tokenId?: BigNumberish,
-    tokenType?: NftTokenType
-  ): Promise<Nft> {
-    return getNftMetadata(this, contractAddressOrBaseNft, tokenId, tokenType);
-  }
-
-  /**
-   * Get the NFT collection metadata associated with the provided parameters.
-   *
-   * @param contractAddress - The contract address of the NFT.
-   * @public
-   */
-  getNftContractMetadata(contractAddress: string): Promise<NftContract>;
-  /**
-   * Get the NFT metadata associated with the provided Base NFT.
-   *
-   * @param baseNftContract - The base NFT contract object to be used for the request.
-   * @public
-   */
-  getNftContractMetadata(
-    baseNftContract: BaseNftContract
-  ): Promise<NftContract>;
-  getNftContractMetadata(
-    contractAddressOrBaseNftContract: string | BaseNftContract
-  ): Promise<NftContract> {
-    return getNftContractMetadata(this, contractAddressOrBaseNftContract);
-  }
-
-  /**
-   * Fetches all NFTs for a given owner and yields them in an async iterable.
-   *
-   * This method returns the full NFT for the owner and pages through all page
-   * keys until all NFTs have been fetched.
-   *
-   * @param owner - The address of the owner.
-   * @param options - The optional parameters to use for the request.
-   * @public
-   */
-  getNftsForOwnerIterator(
-    owner: string,
-    options?: GetNftsForOwnerOptions
-  ): AsyncIterable<OwnedNft>;
-  /**
-   * Fetches all NFTs for a given owner and yields them in an async iterable.
-   *
-   * This method returns the base NFTs that omit the associated metadata and
-   * pages through all page keys until all NFTs have been fetched.
-   *
-   * @param owner - The address of the owner.
-   * @param options - The optional parameters to use for the request.
-   * @public
-   */
-  getNftsForOwnerIterator(
-    owner: string,
-    options?: GetBaseNftsForOwnerOptions
-  ): AsyncIterable<OwnedBaseNft>;
-  getNftsForOwnerIterator(
-    owner: string,
-    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
-  ): AsyncIterable<OwnedBaseNft | OwnedNft> {
-    return getNftsForOwnerIterator(this, owner, options);
-  }
-
-  /**
-   * Get all NFTs for an owner.
-   *
-   * This method returns the full NFTs in the contract. To get all NFTs without
-   * their associated metadata, use {@link GetBaseNftsForOwnerOptions}.
-   *
-   * @param owner - The address of the owner.
-   * @param options - The optional parameters to use for the request.
-   * @public
-   */
-  getNftsForOwner(
-    owner: string,
-    options?: GetNftsForOwnerOptions
-  ): Promise<OwnedNftsResponse>;
-  /**
-   * Get all base NFTs for an owner.
-   *
-   * This method returns the base NFTs that omit the associated metadata. To get
-   * all NFTs with their associated metadata, use {@link GetNftsForOwnerOptions}.
-   *
-   * @param owner - The address of the owner.
-   * @param options - The optional parameters to use for the request.
-   * @public
-   */
-  getNftsForOwner(
-    owner: string,
-    options?: GetBaseNftsForOwnerOptions
-  ): Promise<OwnedBaseNftsResponse>;
-  getNftsForOwner(
-    owner: string,
-    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
-  ): Promise<OwnedNftsResponse | OwnedBaseNftsResponse> {
-    return getNftsForOwner(this, owner, options);
-  }
-
-  /**
-   * Get all NFTs for a given contract address.
-   *
-   * This method returns the full NFTs in the contract. To get all NFTs without
-   * their associated metadata, use {@link GetBaseNftsForNftContractOptions}.
-   *
-   * @param contractAddress - The contract address of the NFT contract.
-   * @param options - The parameters to use for the request. or
-   *   {@link NftContractNftsResponse} response.
-   * @beta
-   */
-  getNftsForNftContract(
-    contractAddress: string,
-    options?: GetNftsForNftContractOptions
-  ): Promise<NftContractNftsResponse>;
-  /**
-   * Get all base NFTs for a given contract address.
-   *
-   * This method returns the base NFTs that omit the associated metadata. To get
-   * all NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
-   *
-   * @param contractAddress - The contract address of the NFT contract.
-   * @param options - The optional parameters to use for the request.
-   * @beta
-   */
-  getNftsForNftContract(
-    contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions
-  ): Promise<NftContractBaseNftsResponse>;
-  getNftsForNftContract(
-    contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
-  ): Promise<NftContractNftsResponse | NftContractBaseNftsResponse> {
-    return getNftsForNftContract(this, contractAddress, options);
-  }
-
-  /**
-   * Fetches all NFTs for a given contract address and yields them in an async iterable.
-   *
-   * This method returns the full NFTs in the contract and pages through all
-   * page keys until all NFTs have been fetched. To get all NFTs without their
-   * associated metadata, use {@link GetBaseNftsForNftContractOptions}.
-   *
-   * @param contractAddress - The contract address of the NFT contract.
-   * @param options - The optional parameters to use for the request.
-   * @beta
-   */
-  getNftsForNftContractIterator(
-    contractAddress: string,
-    options?: GetNftsForNftContractOptions
-  ): AsyncIterable<Nft>;
-  /**
-   * Fetches all base NFTs for a given contract address and yields them in an
-   * async iterable.
-   *
-   * This method returns the base NFTs that omit the associated metadata and
-   * pages through all page keys until all NFTs have been fetched. To get all
-   * NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
-   *
-   * @param contractAddress - The contract address of the NFT contract.
-   * @param options - The optional parameters to use for the request.
-   * @beta
-   */
-  getNftsForNftContractIterator(
-    contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions
-  ): AsyncIterable<BaseNft>;
-  getNftsForNftContractIterator(
-    contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
-  ): AsyncIterable<BaseNft | Nft> {
-    return getNftsForNftContractIterator(this, contractAddress, options);
-  }
-
-  /**
-   * Gets all the owners for a given NFT contract.
-   *
-   * @param contractAddress - The NFT contract to get the owners for.
-   * @beta
-   */
-  getOwnersForNftContract(
-    contractAddress: string
-  ): Promise<GetOwnersForNftContractResponse>;
-  /**
-   * Gets all the owners for a given NFT contract.
-   *
-   * @param nft - The NFT to get the owners of the NFT contract for.
-   * @beta
-   */
-  getOwnersForNftContract(
-    nft: BaseNft
-  ): Promise<GetOwnersForNftContractResponse>;
-  getOwnersForNftContract(
-    contractAddressOrNft: string | BaseNft
-  ): Promise<GetOwnersForNftContractResponse> {
-    return getOwnersForNftContract(this, contractAddressOrNft);
-  }
-
-  /**
-   * Gets all the owners for a given NFT contract address and token ID.
-   *
-   * @param contractAddress - The NFT contract address.
-   * @param tokenId - Token id of the NFT.
-   * @beta
-   */
-  getOwnersForNft(
-    contractAddress: string,
-    tokenId: BigNumberish
-  ): Promise<GetOwnersForNftResponse>;
-  /**
-   * Gets all the owners for a given NFT.
-   *
-   * @param nft - The NFT object to get the owners for.
-   * @beta
-   */
-  getOwnersForNft(nft: BaseNft): Promise<GetOwnersForNftResponse>;
-  getOwnersForNft(
-    contractAddressOrNft: string | BaseNft,
-    tokenId?: BigNumberish
-  ): Promise<GetOwnersForNftResponse> {
-    return getOwnersForNft(this, contractAddressOrNft, tokenId);
-  }
-
-  /**
-   * Checks that the provided owner address owns one of more of the provided NFTs.
-   *
-   * @param owner - The owner address to check.
-   * @param contractAddresses - An array of NFT contract addresses to check ownership for.
-   * @beta
-   */
-  checkNftOwnership(
-    owner: string,
-    contractAddresses: string[]
-  ): Promise<boolean> {
-    return checkNftOwnership(this, owner, contractAddresses);
-  }
-
-  /**
-   * Returns whether a contract is marked as spam or not by Alchemy. For more
-   * information on how we classify spam, go to our NFT API FAQ at
-   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
-   *
-   * @param contractAddress - The contract address to check.
-   * @beta
-   */
-  isSpamNftContract(contractAddress: string): Promise<boolean> {
-    return isSpamNftContract(this, contractAddress);
-  }
-
-  /**
-   * Returns a list of all spam contracts marked by Alchemy. For details on how
-   * Alchemy marks spam contracts, go to
-   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
-   *
-   * @beta
-   */
-  getSpamNftContracts(): Promise<string[]> {
-    return getSpamNftContracts(this);
-  }
-
-  /**
-   * Returns the floor prices of a NFT contract by marketplace.
-   *
-   * @param contractAddress - The contract address for the NFT collection.
-   * @beta
-   */
-  getNftFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
-    return getNftFloorPrice(this, contractAddress);
   }
 
   /**
@@ -419,79 +102,6 @@ export class Alchemy {
    */
   findContractDeployer(contractAddress: string): Promise<DeployResult> {
     return findContractDeployer(this, contractAddress);
-  }
-
-  /**
-   * Refreshes the cached metadata for a provided NFT contract address and token
-   * id. Returns a boolean value indicating whether the metadata was refreshed.
-   *
-   * This method is useful when you want to refresh the metadata for a NFT that
-   * has been updated since the last time it was fetched. Note that the backend
-   * only allows one refresh per token every 15 minutes, globally for all users.
-   * The last refresh time for an NFT can be accessed on the
-   * {@link Nft.timeLastUpdated} field.
-   *
-   * To trigger a refresh for all NFTs in a contract, use
-   * {@link refreshNftContract} instead.
-   *
-   * @param contractAddress - The contract address of the NFT.
-   * @param tokenId - The token id of the NFT.
-   */
-  refreshNftMetadata(
-    contractAddress: string,
-    tokenId: BigNumberish
-  ): Promise<boolean>;
-  /**
-   * Refreshes the cached metadata for a provided NFT contract address and token
-   * id. Returns a boolean value indicating whether the metadata was refreshed.
-   *
-   * This method is useful when you want to refresh the metadata for a NFT that
-   * has been updated since the last time it was fetched. Note that the backend
-   * only allows one refresh per token every 15 minutes, globally for all users.
-   *
-   * To trigger a refresh for all NFTs in a contract, use
-   * {@link refreshNftContract} instead.
-   *
-   * @param nft - The NFT to refresh the metadata for.
-   */
-  refreshNftMetadata(nft: BaseNft): Promise<boolean>;
-  refreshNftMetadata(
-    contractAddressOrBaseNft: string | BaseNft,
-    tokenId?: BigNumberish
-  ): Promise<boolean> {
-    return refreshNftMetadata(this, contractAddressOrBaseNft, tokenId);
-  }
-
-  /**
-   * Triggers a metadata refresh all NFTs in the provided contract address. This
-   * method is useful after an NFT collection is revealed.
-   *
-   * Refreshes are queued on the Alchemy backend and may take time to fully
-   * process. To refresh the metadata for a specific token, use the
-   * {@link refreshNftMetadata} method instead.
-   *
-   * @param contractAddress - The contract address of the NFT collection.
-   * @beta
-   */
-  refreshNftContract(
-    contractAddress: string
-  ): Promise<RefreshNftContractResult>;
-  /**
-   * Triggers a metadata refresh all NFTs in the provided contract address. This
-   * method is useful after an NFT collection is revealed.
-   *
-   * Refreshes are queued on the Alchemy backend and may take time to fully
-   * process. To refresh the metadata for a specific token, use the
-   * {@link refreshNftMetadata} method instead.
-   *
-   * @param nft - The contract address of the NFT collection.
-   * @beta
-   */
-  refreshNftContract(nft: BaseNft): Promise<RefreshNftContractResult>;
-  refreshNftContract(
-    contractAddressOrBaseNft: string | BaseNft
-  ): Promise<RefreshNftContractResult> {
-    return refreshNftContract(this, contractAddressOrBaseNft);
   }
 
   /**

--- a/src/api/nft-module.ts
+++ b/src/api/nft-module.ts
@@ -1,12 +1,12 @@
 import { Alchemy } from './alchemy';
 import { BigNumberish } from '@ethersproject/bignumber';
 import {
-  GetBaseNftsForNftContractOptions,
+  GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
   GetNftFloorPriceResponse,
-  GetNftsForNftContractOptions,
+  GetNftsForContractOptions,
   GetNftsForOwnerOptions,
-  GetOwnersForNftContractResponse,
+  GetOwnersForContractResponse,
   GetOwnersForNftResponse,
   NftContractBaseNftsResponse,
   NftContractNftsResponse,
@@ -15,22 +15,22 @@ import {
   OwnedBaseNftsResponse,
   OwnedNft,
   OwnedNftsResponse,
-  RefreshNftContractResult
+  RefreshContractResult
 } from '../types/types';
 import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
 import {
   checkNftOwnership,
   getNftContractMetadata,
-  getNftFloorPrice,
+  getFloorPrice,
   getNftMetadata,
-  getNftsForNftContract,
+  getNftsForContract,
   getNftsForNftContractIterator,
   getNftsForOwner,
   getNftsForOwnerIterator,
   getOwnersForNft,
-  getOwnersForNftContract,
-  getSpamNftContracts,
-  isSpamNftContract,
+  getOwnersForContract,
+  getSpamContracts,
+  isSpamContract,
   refreshNftContract,
   refreshNftMetadata
 } from '../internal/nft-api';
@@ -170,36 +170,36 @@ export class NftModule {
    * Get all NFTs for a given contract address.
    *
    * This method returns the full NFTs in the contract. To get all NFTs without
-   * their associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   * their associated metadata, use {@link GetBaseNftsForContractOptions}.
    *
    * @param contractAddress - The contract address of the NFT contract.
    * @param options - The parameters to use for the request. or
    *   {@link NftContractNftsResponse} response.
    * @beta
    */
-  getNftsForNftContract(
+  getNftsForContract(
     contractAddress: string,
-    options?: GetNftsForNftContractOptions
+    options?: GetNftsForContractOptions
   ): Promise<NftContractNftsResponse>;
   /**
    * Get all base NFTs for a given contract address.
    *
    * This method returns the base NFTs that omit the associated metadata. To get
-   * all NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   * all NFTs with their associated metadata, use {@link GetNftsForContractOptions}.
    *
    * @param contractAddress - The contract address of the NFT contract.
    * @param options - The optional parameters to use for the request.
    * @beta
    */
-  getNftsForNftContract(
+  getNftsForContract(
     contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions
+    options?: GetBaseNftsForContractOptions
   ): Promise<NftContractBaseNftsResponse>;
-  getNftsForNftContract(
+  getNftsForContract(
     contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+    options?: GetBaseNftsForContractOptions | GetNftsForContractOptions
   ): Promise<NftContractNftsResponse | NftContractBaseNftsResponse> {
-    return getNftsForNftContract(this.alchemy, contractAddress, options);
+    return getNftsForContract(this.alchemy, contractAddress, options);
   }
 
   /**
@@ -207,15 +207,15 @@ export class NftModule {
    *
    * This method returns the full NFTs in the contract and pages through all
    * page keys until all NFTs have been fetched. To get all NFTs without their
-   * associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   * associated metadata, use {@link GetBaseNftsForContractOptions}.
    *
    * @param contractAddress - The contract address of the NFT contract.
    * @param options - The optional parameters to use for the request.
    * @beta
    */
-  getNftsForNftContractIterator(
+  getNftsForContractIterator(
     contractAddress: string,
-    options?: GetNftsForNftContractOptions
+    options?: GetNftsForContractOptions
   ): AsyncIterable<Nft>;
   /**
    * Fetches all base NFTs for a given contract address and yields them in an
@@ -223,19 +223,19 @@ export class NftModule {
    *
    * This method returns the base NFTs that omit the associated metadata and
    * pages through all page keys until all NFTs have been fetched. To get all
-   * NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   * NFTs with their associated metadata, use {@link GetNftsForContractOptions}.
    *
    * @param contractAddress - The contract address of the NFT contract.
    * @param options - The optional parameters to use for the request.
    * @beta
    */
-  getNftsForNftContractIterator(
+  getNftsForContractIterator(
     contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions
+    options?: GetBaseNftsForContractOptions
   ): AsyncIterable<BaseNft>;
-  getNftsForNftContractIterator(
+  getNftsForContractIterator(
     contractAddress: string,
-    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+    options?: GetBaseNftsForContractOptions | GetNftsForContractOptions
   ): AsyncIterable<BaseNft | Nft> {
     return getNftsForNftContractIterator(
       this.alchemy,
@@ -250,22 +250,20 @@ export class NftModule {
    * @param contractAddress - The NFT contract to get the owners for.
    * @beta
    */
-  getOwnersForNftContract(
+  getOwnersForContract(
     contractAddress: string
-  ): Promise<GetOwnersForNftContractResponse>;
+  ): Promise<GetOwnersForContractResponse>;
   /**
    * Gets all the owners for a given NFT contract.
    *
    * @param nft - The NFT to get the owners of the NFT contract for.
    * @beta
    */
-  getOwnersForNftContract(
-    nft: BaseNft
-  ): Promise<GetOwnersForNftContractResponse>;
-  getOwnersForNftContract(
+  getOwnersForContract(nft: BaseNft): Promise<GetOwnersForContractResponse>;
+  getOwnersForContract(
     contractAddressOrNft: string | BaseNft
-  ): Promise<GetOwnersForNftContractResponse> {
-    return getOwnersForNftContract(this.alchemy, contractAddressOrNft);
+  ): Promise<GetOwnersForContractResponse> {
+    return getOwnersForContract(this.alchemy, contractAddressOrNft);
   }
 
   /**
@@ -315,8 +313,8 @@ export class NftModule {
    * @param contractAddress - The contract address to check.
    * @beta
    */
-  isSpamNftContract(contractAddress: string): Promise<boolean> {
-    return isSpamNftContract(this.alchemy, contractAddress);
+  isSpamContract(contractAddress: string): Promise<boolean> {
+    return isSpamContract(this.alchemy, contractAddress);
   }
 
   /**
@@ -326,8 +324,8 @@ export class NftModule {
    *
    * @beta
    */
-  getSpamNftContracts(): Promise<string[]> {
-    return getSpamNftContracts(this.alchemy);
+  getSpamContracts(): Promise<string[]> {
+    return getSpamContracts(this.alchemy);
   }
 
   /**
@@ -336,8 +334,8 @@ export class NftModule {
    * @param contractAddress - The contract address for the NFT collection.
    * @beta
    */
-  getNftFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
-    return getNftFloorPrice(this.alchemy, contractAddress);
+  getFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
+    return getFloorPrice(this.alchemy, contractAddress);
   }
 
   /**
@@ -350,8 +348,7 @@ export class NftModule {
    * The last refresh time for an NFT can be accessed on the
    * {@link Nft.timeLastUpdated} field.
    *
-   * To trigger a refresh for all NFTs in a contract, use
-   * {@link refreshNftContract} instead.
+   * To trigger a refresh for all NFTs in a contract, use {@link refreshContract} instead.
    *
    * @param contractAddress - The contract address of the NFT.
    * @param tokenId - The token id of the NFT.
@@ -368,8 +365,7 @@ export class NftModule {
    * has been updated since the last time it was fetched. Note that the backend
    * only allows one refresh per token every 15 minutes, globally for all users.
    *
-   * To trigger a refresh for all NFTs in a contract, use
-   * {@link refreshNftContract} instead.
+   * To trigger a refresh for all NFTs in a contract, use {@link refreshContract} instead.
    *
    * @param nft - The NFT to refresh the metadata for.
    */
@@ -392,9 +388,7 @@ export class NftModule {
    * @param contractAddress - The contract address of the NFT collection.
    * @beta
    */
-  refreshNftContract(
-    contractAddress: string
-  ): Promise<RefreshNftContractResult>;
+  refreshContract(contractAddress: string): Promise<RefreshContractResult>;
   /**
    * Triggers a metadata refresh all NFTs in the provided contract address. This
    * method is useful after an NFT collection is revealed.
@@ -406,10 +400,10 @@ export class NftModule {
    * @param nft - The contract address of the NFT collection.
    * @beta
    */
-  refreshNftContract(nft: BaseNft): Promise<RefreshNftContractResult>;
-  refreshNftContract(
+  refreshContract(nft: BaseNft): Promise<RefreshContractResult>;
+  refreshContract(
     contractAddressOrBaseNft: string | BaseNft
-  ): Promise<RefreshNftContractResult> {
+  ): Promise<RefreshContractResult> {
     return refreshNftContract(this.alchemy, contractAddressOrBaseNft);
   }
 }

--- a/src/api/nft-module.ts
+++ b/src/api/nft-module.ts
@@ -3,7 +3,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import {
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
-  GetNftFloorPriceResponse,
+  GetFloorPriceResponse,
   GetNftsForContractOptions,
   GetNftsForOwnerOptions,
   GetOwnersForContractResponse,
@@ -17,7 +17,7 @@ import {
   OwnedNftsResponse,
   RefreshContractResult
 } from '../types/types';
-import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
+import { BaseNft, Nft, NftContract } from './nft';
 import {
   checkNftOwnership,
   getNftContractMetadata,
@@ -50,25 +50,8 @@ export class NftModule {
     contractAddress: string,
     tokenId: BigNumberish,
     tokenType?: NftTokenType
-  ): Promise<Nft>;
-  /**
-   * Get the NFT metadata associated with the provided Base NFT.
-   *
-   * @param baseNft - The base NFT object to be used for the request.
-   * @public
-   */
-  getNftMetadata(baseNft: BaseNft): Promise<Nft>;
-  getNftMetadata(
-    contractAddressOrBaseNft: string | BaseNft,
-    tokenId?: BigNumberish,
-    tokenType?: NftTokenType
   ): Promise<Nft> {
-    return getNftMetadata(
-      this.alchemy,
-      contractAddressOrBaseNft,
-      tokenId,
-      tokenType
-    );
+    return getNftMetadata(this.alchemy, contractAddress, tokenId, tokenType);
   }
 
   /**
@@ -77,23 +60,8 @@ export class NftModule {
    * @param contractAddress - The contract address of the NFT.
    * @public
    */
-  getNftContractMetadata(contractAddress: string): Promise<NftContract>;
-  /**
-   * Get the NFT metadata associated with the provided Base NFT.
-   *
-   * @param baseNftContract - The base NFT contract object to be used for the request.
-   * @public
-   */
-  getNftContractMetadata(
-    baseNftContract: BaseNftContract
-  ): Promise<NftContract>;
-  getNftContractMetadata(
-    contractAddressOrBaseNftContract: string | BaseNftContract
-  ): Promise<NftContract> {
-    return getNftContractMetadata(
-      this.alchemy,
-      contractAddressOrBaseNftContract
-    );
+  getNftContractMetadata(contractAddress: string): Promise<NftContract> {
+    return getNftContractMetadata(this.alchemy, contractAddress);
   }
 
   /**
@@ -252,18 +220,8 @@ export class NftModule {
    */
   getOwnersForContract(
     contractAddress: string
-  ): Promise<GetOwnersForContractResponse>;
-  /**
-   * Gets all the owners for a given NFT contract.
-   *
-   * @param nft - The NFT to get the owners of the NFT contract for.
-   * @beta
-   */
-  getOwnersForContract(nft: BaseNft): Promise<GetOwnersForContractResponse>;
-  getOwnersForContract(
-    contractAddressOrNft: string | BaseNft
   ): Promise<GetOwnersForContractResponse> {
-    return getOwnersForContract(this.alchemy, contractAddressOrNft);
+    return getOwnersForContract(this.alchemy, contractAddress);
   }
 
   /**
@@ -276,19 +234,8 @@ export class NftModule {
   getOwnersForNft(
     contractAddress: string,
     tokenId: BigNumberish
-  ): Promise<GetOwnersForNftResponse>;
-  /**
-   * Gets all the owners for a given NFT.
-   *
-   * @param nft - The NFT object to get the owners for.
-   * @beta
-   */
-  getOwnersForNft(nft: BaseNft): Promise<GetOwnersForNftResponse>;
-  getOwnersForNft(
-    contractAddressOrNft: string | BaseNft,
-    tokenId?: BigNumberish
   ): Promise<GetOwnersForNftResponse> {
-    return getOwnersForNft(this.alchemy, contractAddressOrNft, tokenId);
+    return getOwnersForNft(this.alchemy, contractAddress, tokenId);
   }
 
   /**
@@ -334,7 +281,7 @@ export class NftModule {
    * @param contractAddress - The contract address for the NFT collection.
    * @beta
    */
-  getFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
+  getFloorPrice(contractAddress: string): Promise<GetFloorPriceResponse> {
     return getFloorPrice(this.alchemy, contractAddress);
   }
 
@@ -356,25 +303,8 @@ export class NftModule {
   refreshNftMetadata(
     contractAddress: string,
     tokenId: BigNumberish
-  ): Promise<boolean>;
-  /**
-   * Refreshes the cached metadata for a provided NFT contract address and token
-   * id. Returns a boolean value indicating whether the metadata was refreshed.
-   *
-   * This method is useful when you want to refresh the metadata for a NFT that
-   * has been updated since the last time it was fetched. Note that the backend
-   * only allows one refresh per token every 15 minutes, globally for all users.
-   *
-   * To trigger a refresh for all NFTs in a contract, use {@link refreshContract} instead.
-   *
-   * @param nft - The NFT to refresh the metadata for.
-   */
-  refreshNftMetadata(nft: BaseNft): Promise<boolean>;
-  refreshNftMetadata(
-    contractAddressOrBaseNft: string | BaseNft,
-    tokenId?: BigNumberish
   ): Promise<boolean> {
-    return refreshNftMetadata(this.alchemy, contractAddressOrBaseNft, tokenId);
+    return refreshNftMetadata(this.alchemy, contractAddress, tokenId);
   }
 
   /**
@@ -388,22 +318,7 @@ export class NftModule {
    * @param contractAddress - The contract address of the NFT collection.
    * @beta
    */
-  refreshContract(contractAddress: string): Promise<RefreshContractResult>;
-  /**
-   * Triggers a metadata refresh all NFTs in the provided contract address. This
-   * method is useful after an NFT collection is revealed.
-   *
-   * Refreshes are queued on the Alchemy backend and may take time to fully
-   * process. To refresh the metadata for a specific token, use the
-   * {@link refreshNftMetadata} method instead.
-   *
-   * @param nft - The contract address of the NFT collection.
-   * @beta
-   */
-  refreshContract(nft: BaseNft): Promise<RefreshContractResult>;
-  refreshContract(
-    contractAddressOrBaseNft: string | BaseNft
-  ): Promise<RefreshContractResult> {
-    return refreshNftContract(this.alchemy, contractAddressOrBaseNft);
+  refreshContract(contractAddress: string): Promise<RefreshContractResult> {
+    return refreshNftContract(this.alchemy, contractAddress);
   }
 }

--- a/src/api/nft-module.ts
+++ b/src/api/nft-module.ts
@@ -1,0 +1,415 @@
+import { Alchemy } from './alchemy';
+import { BigNumberish } from '@ethersproject/bignumber';
+import {
+  GetBaseNftsForNftContractOptions,
+  GetBaseNftsForOwnerOptions,
+  GetNftFloorPriceResponse,
+  GetNftsForNftContractOptions,
+  GetNftsForOwnerOptions,
+  GetOwnersForNftContractResponse,
+  GetOwnersForNftResponse,
+  NftContractBaseNftsResponse,
+  NftContractNftsResponse,
+  NftTokenType,
+  OwnedBaseNft,
+  OwnedBaseNftsResponse,
+  OwnedNft,
+  OwnedNftsResponse,
+  RefreshNftContractResult
+} from '../types/types';
+import { BaseNft, BaseNftContract, Nft, NftContract } from './nft';
+import {
+  checkNftOwnership,
+  getNftContractMetadata,
+  getNftFloorPrice,
+  getNftMetadata,
+  getNftsForNftContract,
+  getNftsForNftContractIterator,
+  getNftsForOwner,
+  getNftsForOwnerIterator,
+  getOwnersForNft,
+  getOwnersForNftContract,
+  getSpamNftContracts,
+  isSpamNftContract,
+  refreshNftContract,
+  refreshNftMetadata
+} from '../internal/nft-api';
+
+export class NftModule {
+  constructor(private readonly alchemy: Alchemy) {}
+
+  /**
+   * Get the NFT metadata associated with the provided parameters.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @param tokenId - Token id of the NFT.
+   * @param tokenType - Optionally specify the type of token to speed up the query.
+   * @public
+   */
+  getNftMetadata(
+    contractAddress: string,
+    tokenId: BigNumberish,
+    tokenType?: NftTokenType
+  ): Promise<Nft>;
+  /**
+   * Get the NFT metadata associated with the provided Base NFT.
+   *
+   * @param baseNft - The base NFT object to be used for the request.
+   * @public
+   */
+  getNftMetadata(baseNft: BaseNft): Promise<Nft>;
+  getNftMetadata(
+    contractAddressOrBaseNft: string | BaseNft,
+    tokenId?: BigNumberish,
+    tokenType?: NftTokenType
+  ): Promise<Nft> {
+    return getNftMetadata(
+      this.alchemy,
+      contractAddressOrBaseNft,
+      tokenId,
+      tokenType
+    );
+  }
+
+  /**
+   * Get the NFT collection metadata associated with the provided parameters.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @public
+   */
+  getNftContractMetadata(contractAddress: string): Promise<NftContract>;
+  /**
+   * Get the NFT metadata associated with the provided Base NFT.
+   *
+   * @param baseNftContract - The base NFT contract object to be used for the request.
+   * @public
+   */
+  getNftContractMetadata(
+    baseNftContract: BaseNftContract
+  ): Promise<NftContract>;
+  getNftContractMetadata(
+    contractAddressOrBaseNftContract: string | BaseNftContract
+  ): Promise<NftContract> {
+    return getNftContractMetadata(
+      this.alchemy,
+      contractAddressOrBaseNftContract
+    );
+  }
+
+  /**
+   * Fetches all NFTs for a given owner and yields them in an async iterable.
+   *
+   * This method returns the full NFT for the owner and pages through all page
+   * keys until all NFTs have been fetched.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetNftsForOwnerOptions
+  ): AsyncIterable<OwnedNft>;
+  /**
+   * Fetches all NFTs for a given owner and yields them in an async iterable.
+   *
+   * This method returns the base NFTs that omit the associated metadata and
+   * pages through all page keys until all NFTs have been fetched.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetBaseNftsForOwnerOptions
+  ): AsyncIterable<OwnedBaseNft>;
+  getNftsForOwnerIterator(
+    owner: string,
+    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
+  ): AsyncIterable<OwnedBaseNft | OwnedNft> {
+    return getNftsForOwnerIterator(this.alchemy, owner, options);
+  }
+
+  /**
+   * Get all NFTs for an owner.
+   *
+   * This method returns the full NFTs in the contract. To get all NFTs without
+   * their associated metadata, use {@link GetBaseNftsForOwnerOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwner(
+    owner: string,
+    options?: GetNftsForOwnerOptions
+  ): Promise<OwnedNftsResponse>;
+  /**
+   * Get all base NFTs for an owner.
+   *
+   * This method returns the base NFTs that omit the associated metadata. To get
+   * all NFTs with their associated metadata, use {@link GetNftsForOwnerOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwner(
+    owner: string,
+    options?: GetBaseNftsForOwnerOptions
+  ): Promise<OwnedBaseNftsResponse>;
+  getNftsForOwner(
+    owner: string,
+    options?: GetNftsForOwnerOptions | GetBaseNftsForOwnerOptions
+  ): Promise<OwnedNftsResponse | OwnedBaseNftsResponse> {
+    return getNftsForOwner(this.alchemy, owner, options);
+  }
+
+  /**
+   * Get all NFTs for a given contract address.
+   *
+   * This method returns the full NFTs in the contract. To get all NFTs without
+   * their associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The parameters to use for the request. or
+   *   {@link NftContractNftsResponse} response.
+   * @beta
+   */
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetNftsForNftContractOptions
+  ): Promise<NftContractNftsResponse>;
+  /**
+   * Get all base NFTs for a given contract address.
+   *
+   * This method returns the base NFTs that omit the associated metadata. To get
+   * all NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions
+  ): Promise<NftContractBaseNftsResponse>;
+  getNftsForNftContract(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  ): Promise<NftContractNftsResponse | NftContractBaseNftsResponse> {
+    return getNftsForNftContract(this.alchemy, contractAddress, options);
+  }
+
+  /**
+   * Fetches all NFTs for a given contract address and yields them in an async iterable.
+   *
+   * This method returns the full NFTs in the contract and pages through all
+   * page keys until all NFTs have been fetched. To get all NFTs without their
+   * associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetNftsForNftContractOptions
+  ): AsyncIterable<Nft>;
+  /**
+   * Fetches all base NFTs for a given contract address and yields them in an
+   * async iterable.
+   *
+   * This method returns the base NFTs that omit the associated metadata and
+   * pages through all page keys until all NFTs have been fetched. To get all
+   * NFTs with their associated metadata, use {@link GetNftsForNftContractOptions}.
+   *
+   * @param contractAddress - The contract address of the NFT contract.
+   * @param options - The optional parameters to use for the request.
+   * @beta
+   */
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions
+  ): AsyncIterable<BaseNft>;
+  getNftsForNftContractIterator(
+    contractAddress: string,
+    options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  ): AsyncIterable<BaseNft | Nft> {
+    return getNftsForNftContractIterator(
+      this.alchemy,
+      contractAddress,
+      options
+    );
+  }
+
+  /**
+   * Gets all the owners for a given NFT contract.
+   *
+   * @param contractAddress - The NFT contract to get the owners for.
+   * @beta
+   */
+  getOwnersForNftContract(
+    contractAddress: string
+  ): Promise<GetOwnersForNftContractResponse>;
+  /**
+   * Gets all the owners for a given NFT contract.
+   *
+   * @param nft - The NFT to get the owners of the NFT contract for.
+   * @beta
+   */
+  getOwnersForNftContract(
+    nft: BaseNft
+  ): Promise<GetOwnersForNftContractResponse>;
+  getOwnersForNftContract(
+    contractAddressOrNft: string | BaseNft
+  ): Promise<GetOwnersForNftContractResponse> {
+    return getOwnersForNftContract(this.alchemy, contractAddressOrNft);
+  }
+
+  /**
+   * Gets all the owners for a given NFT contract address and token ID.
+   *
+   * @param contractAddress - The NFT contract address.
+   * @param tokenId - Token id of the NFT.
+   * @beta
+   */
+  getOwnersForNft(
+    contractAddress: string,
+    tokenId: BigNumberish
+  ): Promise<GetOwnersForNftResponse>;
+  /**
+   * Gets all the owners for a given NFT.
+   *
+   * @param nft - The NFT object to get the owners for.
+   * @beta
+   */
+  getOwnersForNft(nft: BaseNft): Promise<GetOwnersForNftResponse>;
+  getOwnersForNft(
+    contractAddressOrNft: string | BaseNft,
+    tokenId?: BigNumberish
+  ): Promise<GetOwnersForNftResponse> {
+    return getOwnersForNft(this.alchemy, contractAddressOrNft, tokenId);
+  }
+
+  /**
+   * Checks that the provided owner address owns one of more of the provided NFTs.
+   *
+   * @param owner - The owner address to check.
+   * @param contractAddresses - An array of NFT contract addresses to check ownership for.
+   * @beta
+   */
+  checkNftOwnership(
+    owner: string,
+    contractAddresses: string[]
+  ): Promise<boolean> {
+    return checkNftOwnership(this.alchemy, owner, contractAddresses);
+  }
+
+  /**
+   * Returns whether a contract is marked as spam or not by Alchemy. For more
+   * information on how we classify spam, go to our NFT API FAQ at
+   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
+   *
+   * @param contractAddress - The contract address to check.
+   * @beta
+   */
+  isSpamNftContract(contractAddress: string): Promise<boolean> {
+    return isSpamNftContract(this.alchemy, contractAddress);
+  }
+
+  /**
+   * Returns a list of all spam contracts marked by Alchemy. For details on how
+   * Alchemy marks spam contracts, go to
+   * https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification.
+   *
+   * @beta
+   */
+  getSpamNftContracts(): Promise<string[]> {
+    return getSpamNftContracts(this.alchemy);
+  }
+
+  /**
+   * Returns the floor prices of a NFT contract by marketplace.
+   *
+   * @param contractAddress - The contract address for the NFT collection.
+   * @beta
+   */
+  getNftFloorPrice(contractAddress: string): Promise<GetNftFloorPriceResponse> {
+    return getNftFloorPrice(this.alchemy, contractAddress);
+  }
+
+  /**
+   * Refreshes the cached metadata for a provided NFT contract address and token
+   * id. Returns a boolean value indicating whether the metadata was refreshed.
+   *
+   * This method is useful when you want to refresh the metadata for a NFT that
+   * has been updated since the last time it was fetched. Note that the backend
+   * only allows one refresh per token every 15 minutes, globally for all users.
+   * The last refresh time for an NFT can be accessed on the
+   * {@link Nft.timeLastUpdated} field.
+   *
+   * To trigger a refresh for all NFTs in a contract, use
+   * {@link refreshNftContract} instead.
+   *
+   * @param contractAddress - The contract address of the NFT.
+   * @param tokenId - The token id of the NFT.
+   */
+  refreshNftMetadata(
+    contractAddress: string,
+    tokenId: BigNumberish
+  ): Promise<boolean>;
+  /**
+   * Refreshes the cached metadata for a provided NFT contract address and token
+   * id. Returns a boolean value indicating whether the metadata was refreshed.
+   *
+   * This method is useful when you want to refresh the metadata for a NFT that
+   * has been updated since the last time it was fetched. Note that the backend
+   * only allows one refresh per token every 15 minutes, globally for all users.
+   *
+   * To trigger a refresh for all NFTs in a contract, use
+   * {@link refreshNftContract} instead.
+   *
+   * @param nft - The NFT to refresh the metadata for.
+   */
+  refreshNftMetadata(nft: BaseNft): Promise<boolean>;
+  refreshNftMetadata(
+    contractAddressOrBaseNft: string | BaseNft,
+    tokenId?: BigNumberish
+  ): Promise<boolean> {
+    return refreshNftMetadata(this.alchemy, contractAddressOrBaseNft, tokenId);
+  }
+
+  /**
+   * Triggers a metadata refresh all NFTs in the provided contract address. This
+   * method is useful after an NFT collection is revealed.
+   *
+   * Refreshes are queued on the Alchemy backend and may take time to fully
+   * process. To refresh the metadata for a specific token, use the
+   * {@link refreshNftMetadata} method instead.
+   *
+   * @param contractAddress - The contract address of the NFT collection.
+   * @beta
+   */
+  refreshNftContract(
+    contractAddress: string
+  ): Promise<RefreshNftContractResult>;
+  /**
+   * Triggers a metadata refresh all NFTs in the provided contract address. This
+   * method is useful after an NFT collection is revealed.
+   *
+   * Refreshes are queued on the Alchemy backend and may take time to fully
+   * process. To refresh the metadata for a specific token, use the
+   * {@link refreshNftMetadata} method instead.
+   *
+   * @param nft - The contract address of the NFT collection.
+   * @beta
+   */
+  refreshNftContract(nft: BaseNft): Promise<RefreshNftContractResult>;
+  refreshNftContract(
+    contractAddressOrBaseNft: string | BaseNft
+  ): Promise<RefreshNftContractResult> {
+    return refreshNftContract(this.alchemy, contractAddressOrBaseNft);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export * from './types/types';
 
 export { Alchemy } from './api/alchemy';
 
+export { AlchemyProvider } from './api/alchemy-provider';
+
+export { AlchemyWebSocketProvider } from './api/alchemy-websocket-provider';
+
+export { NftModule } from './api/nft-module';
+
 export { BaseNftContract, NftContract, Nft, BaseNft } from './api/nft';
 
 export { fromHex, toHex, isHex } from './api/util';

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -1,10 +1,10 @@
-import { BaseNft, BaseNftContract, Nft, NftContract } from '../api/nft';
+import { BaseNft, Nft, NftContract } from '../api/nft';
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import {
   DeployResult,
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
-  GetNftFloorPriceResponse,
+  GetFloorPriceResponse,
   GetNftsForContractOptions,
   GetNftsForOwnerOptions,
   GetOwnersForContractResponse,
@@ -48,63 +48,34 @@ const ETH_NULL_VALUE = '0x';
 
 export async function getNftMetadata(
   alchemy: Alchemy,
-  contractAddressOrBaseNft: string | BaseNft,
-  tokenId?: BigNumberish,
+  contractAddress: string,
+  tokenId: BigNumberish,
   tokenType?: NftTokenType
 ): Promise<Nft> {
-  let response;
-  let contractAddress: string;
-  if (typeof contractAddressOrBaseNft === 'string') {
-    contractAddress = contractAddressOrBaseNft;
-    response = await requestHttpWithBackoff<GetNftMetadataParams, RawNft>(
-      alchemy,
-      AlchemyApiType.NFT,
-      'getNFTMetadata',
-      {
-        contractAddress: contractAddressOrBaseNft,
-        tokenId: BigNumber.from(tokenId!).toString(),
-        tokenType: tokenType !== NftTokenType.UNKNOWN ? tokenType : undefined
-      }
-    );
-  } else {
-    contractAddress = contractAddressOrBaseNft.contract.address;
-    response = await requestHttpWithBackoff<GetNftMetadataParams, RawNft>(
-      alchemy,
-      AlchemyApiType.NFT,
-      'getNFTMetadata',
-      {
-        contractAddress: contractAddressOrBaseNft.contract.address,
-        tokenId: BigNumber.from(contractAddressOrBaseNft.tokenId).toString(),
-        tokenType:
-          contractAddressOrBaseNft.tokenType !== NftTokenType.UNKNOWN
-            ? contractAddressOrBaseNft.tokenType
-            : undefined
-      }
-    );
-  }
+  const response = await requestHttpWithBackoff<GetNftMetadataParams, RawNft>(
+    alchemy,
+    AlchemyApiType.NFT,
+    'getNFTMetadata',
+    {
+      contractAddress,
+      tokenId: BigNumber.from(tokenId!).toString(),
+      tokenType: tokenType !== NftTokenType.UNKNOWN ? tokenType : undefined
+    }
+  );
   return getNftFromRaw(response, contractAddress);
 }
 
 export async function getNftContractMetadata(
   alchemy: Alchemy,
-  contractAddressOrBaseNftContract: string | BaseNftContract
+  contractAddress: string
 ): Promise<NftContract> {
-  let response;
-  if (typeof contractAddressOrBaseNftContract === 'string') {
-    response = await requestHttpWithBackoff<
-      GetNftContractMetadataParams,
-      RawNftContract
-    >(alchemy, AlchemyApiType.NFT, 'getContractMetadata', {
-      contractAddress: contractAddressOrBaseNftContract
-    });
-  } else {
-    response = await requestHttpWithBackoff<
-      GetNftContractMetadataParams,
-      RawNftContract
-    >(alchemy, AlchemyApiType.NFT, 'getContractMetadata', {
-      contractAddress: contractAddressOrBaseNftContract.address
-    });
-  }
+  const response = await requestHttpWithBackoff<
+    GetNftContractMetadataParams,
+    RawNftContract
+  >(alchemy, AlchemyApiType.NFT, 'getContractMetadata', {
+    contractAddress
+  });
+
   return getNftContractFromRaw(response);
 }
 
@@ -190,24 +161,14 @@ export async function getNftsForContract(
 
 export async function getOwnersForContract(
   alchemy: Alchemy,
-  contractAddressOrNft: string | BaseNft
+  contractAddress: string
 ): Promise<GetOwnersForContractResponse> {
-  let response;
-  if (typeof contractAddressOrNft === 'string') {
-    response = await requestHttpWithBackoff<
-      GetOwnersForNftContractAlchemyParams,
-      RawGetOwnersForNftContractResponse
-    >(alchemy, AlchemyApiType.NFT, 'getOwnersForCollection', {
-      contractAddress: contractAddressOrNft
-    });
-  } else {
-    response = await requestHttpWithBackoff<
-      GetOwnersForNftContractAlchemyParams,
-      RawGetOwnersForNftContractResponse
-    >(alchemy, AlchemyApiType.NFT, 'getOwnersForCollection', {
-      contractAddress: contractAddressOrNft.contract.address
-    });
-  }
+  const response = await requestHttpWithBackoff<
+    GetOwnersForNftContractAlchemyParams,
+    RawGetOwnersForNftContractResponse
+  >(alchemy, AlchemyApiType.NFT, 'getOwnersForCollection', {
+    contractAddress
+  });
 
   return {
     owners: response.ownerAddresses
@@ -216,30 +177,18 @@ export async function getOwnersForContract(
 
 export function getOwnersForNft(
   alchemy: Alchemy,
-  contractAddressOrNft: string | BaseNft,
+  contractAddress: string,
   tokenId?: BigNumberish
 ): Promise<GetOwnersForNftResponse> {
-  if (typeof contractAddressOrNft === 'string') {
-    return requestHttpWithBackoff(
-      alchemy,
-      AlchemyApiType.NFT,
-      'getOwnersForToken',
-      {
-        contractAddress: contractAddressOrNft,
-        tokenId: BigNumber.from(tokenId!).toString()
-      }
-    );
-  } else {
-    return requestHttpWithBackoff(
-      alchemy,
-      AlchemyApiType.NFT,
-      'getOwnersForToken',
-      {
-        contractAddress: contractAddressOrNft.contract.address,
-        tokenId: BigNumber.from(contractAddressOrNft.tokenId).toString()
-      }
-    );
-  }
+  return requestHttpWithBackoff(
+    alchemy,
+    AlchemyApiType.NFT,
+    'getOwnersForToken',
+    {
+      contractAddress,
+      tokenId: BigNumber.from(tokenId!).toString()
+    }
+  );
 }
 
 export async function* getNftsForNftContractIterator(
@@ -317,8 +266,8 @@ export async function getSpamContracts(alchemy: Alchemy): Promise<string[]> {
 export async function getFloorPrice(
   alchemy: Alchemy,
   contractAddress: string
-): Promise<GetNftFloorPriceResponse> {
-  return requestHttpWithBackoff<GetFloorPriceParams, GetNftFloorPriceResponse>(
+): Promise<GetFloorPriceResponse> {
+  return requestHttpWithBackoff<GetFloorPriceParams, GetFloorPriceResponse>(
     alchemy,
     AlchemyApiType.NFT,
     'getFloorPrice',
@@ -364,18 +313,10 @@ export async function findContractDeployer(
 
 export async function refreshNftMetadata(
   alchemy: Alchemy,
-  contractAddressOrBaseNft: string | BaseNft,
+  contractAddress: string,
   tokenId?: BigNumberish
 ): Promise<boolean> {
-  let contractAddress: string;
-  let tokenIdString: string;
-  if (typeof contractAddressOrBaseNft === 'string') {
-    contractAddress = contractAddressOrBaseNft;
-    tokenIdString = BigNumber.from(tokenId!).toString();
-  } else {
-    contractAddress = contractAddressOrBaseNft.contract.address;
-    tokenIdString = contractAddressOrBaseNft.tokenId;
-  }
+  const tokenIdString = BigNumber.from(tokenId!).toString();
   const first = await getNftMetadata(alchemy, contractAddress, tokenIdString);
   const second = await refresh(alchemy, contractAddress, tokenIdString);
   return first.timeLastUpdated !== second.timeLastUpdated;
@@ -383,24 +324,15 @@ export async function refreshNftMetadata(
 
 export async function refreshNftContract(
   alchemy: Alchemy,
-  contractAddressOrBaseNft: string | BaseNft
+  contractAddress: string
 ): Promise<RefreshContractResult> {
-  let response;
-  if (typeof contractAddressOrBaseNft === 'string') {
-    response = await requestHttpWithBackoff<
-      ReingestContractParams,
-      RawReingestContractResponse
-    >(alchemy, AlchemyApiType.NFT, 'reingestContract', {
-      contractAddress: contractAddressOrBaseNft
-    });
-  } else {
-    response = await requestHttpWithBackoff<
-      ReingestContractParams,
-      RawReingestContractResponse
-    >(alchemy, AlchemyApiType.NFT, 'reingestContract', {
-      contractAddress: contractAddressOrBaseNft.contract.address
-    });
-  }
+  const response = await requestHttpWithBackoff<
+    ReingestContractParams,
+    RawReingestContractResponse
+  >(alchemy, AlchemyApiType.NFT, 'reingestContract', {
+    contractAddress
+  });
+
   return {
     contractAddress: response.contractAddress,
     refreshState: parseReingestionState(response.reingestionState),

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -2,12 +2,12 @@ import { BaseNft, BaseNftContract, Nft, NftContract } from '../api/nft';
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import {
   DeployResult,
-  GetBaseNftsForNftContractOptions,
+  GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
   GetNftFloorPriceResponse,
-  GetNftsForNftContractOptions,
+  GetNftsForContractOptions,
   GetNftsForOwnerOptions,
-  GetOwnersForNftContractResponse,
+  GetOwnersForContractResponse,
   GetOwnersForNftResponse,
   NftContractBaseNftsResponse,
   NftContractNftsResponse,
@@ -16,7 +16,7 @@ import {
   OwnedBaseNftsResponse,
   OwnedNft,
   OwnedNftsResponse,
-  RefreshNftContractResult,
+  RefreshContractResult,
   RefreshState
 } from '../types/types';
 import { paginateEndpoint, requestHttpWithBackoff } from './dispatch';
@@ -165,10 +165,10 @@ export async function getNftsForOwner(
   };
 }
 
-export async function getNftsForNftContract(
+export async function getNftsForContract(
   alchemy: Alchemy,
   contractAddress: string,
-  options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  options?: GetBaseNftsForContractOptions | GetNftsForContractOptions
 ): Promise<NftContractNftsResponse | NftContractBaseNftsResponse> {
   const withMetadata = omitMetadataToWithMetadata(options?.omitMetadata);
   const response = await requestHttpWithBackoff<
@@ -188,10 +188,10 @@ export async function getNftsForNftContract(
   };
 }
 
-export async function getOwnersForNftContract(
+export async function getOwnersForContract(
   alchemy: Alchemy,
   contractAddressOrNft: string | BaseNft
-): Promise<GetOwnersForNftContractResponse> {
+): Promise<GetOwnersForContractResponse> {
   let response;
   if (typeof contractAddressOrNft === 'string') {
     response = await requestHttpWithBackoff<
@@ -245,7 +245,7 @@ export function getOwnersForNft(
 export async function* getNftsForNftContractIterator(
   alchemy: Alchemy,
   contractAddress: string,
-  options?: GetBaseNftsForNftContractOptions | GetNftsForNftContractOptions
+  options?: GetBaseNftsForContractOptions | GetNftsForContractOptions
 ): AsyncIterable<BaseNft | Nft> {
   const withMetadata = omitMetadataToWithMetadata(options?.omitMetadata);
   for await (const response of paginateEndpoint(
@@ -283,7 +283,7 @@ export async function checkNftOwnership(
   return response.ownedNfts.length > 0;
 }
 
-export async function isSpamNftContract(
+export async function isSpamContract(
   alchemy: Alchemy,
   contractAddress: string
 ): Promise<boolean> {
@@ -305,7 +305,7 @@ export async function isSpamNftContract(
  * @param alchemy - The Alchemy SDK instance.
  * @beta
  */
-export async function getSpamNftContracts(alchemy: Alchemy): Promise<string[]> {
+export async function getSpamContracts(alchemy: Alchemy): Promise<string[]> {
   return requestHttpWithBackoff<undefined, string[]>(
     alchemy,
     AlchemyApiType.NFT,
@@ -314,7 +314,7 @@ export async function getSpamNftContracts(alchemy: Alchemy): Promise<string[]> {
   );
 }
 
-export async function getNftFloorPrice(
+export async function getFloorPrice(
   alchemy: Alchemy,
   contractAddress: string
 ): Promise<GetNftFloorPriceResponse> {
@@ -384,7 +384,7 @@ export async function refreshNftMetadata(
 export async function refreshNftContract(
   alchemy: Alchemy,
   contractAddressOrBaseNft: string | BaseNft
-): Promise<RefreshNftContractResult> {
+): Promise<RefreshContractResult> {
   let response;
   if (typeof contractAddressOrBaseNft === 'string') {
     response = await requestHttpWithBackoff<

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -355,7 +355,7 @@ export interface GetOwnersForNftResponse {
 }
 
 /**
- * The response object for the {@link getOwnersForNftContract}.
+ * The response object for the {@link getOwnersForContract}.
  *
  * @public
  */
@@ -365,7 +365,7 @@ export interface GetOwnersForContractResponse {
 }
 
 /**
- * The successful object returned by the {@link getNftFloorPrice} call for each
+ * The successful object returned by the {@link getFloorPrice} call for each
  * marketplace (e.g. looksRare).
  *
  * @public
@@ -382,7 +382,7 @@ export interface FloorPriceMarketplace {
 }
 
 /**
- * The failing object returned by the {@link getNftFloorPrice} call for each
+ * The failing object returned by the {@link getFloorPrice} call for each
  * marketplace (e.g. looksRare).
  *
  * @public
@@ -393,11 +393,11 @@ export interface FloorPriceError {
 }
 
 /**
- * The response object for the {@link getNftFloorPrice} method.
+ * The response object for the {@link getFloorPrice} method.
  *
  * @public
  */
-export interface GetNftFloorPriceResponse {
+export interface GetFloorPriceResponse {
   /**
    * Name of the NFT marketplace where the collection is listed. Current
    * marketplaces supported: OpenSea, LooksRare
@@ -476,7 +476,7 @@ export interface RawContract {
 }
 
 /**
- * Optional parameters object for the {@link getNftsForNftContract} and
+ * Optional parameters object for the {@link getNftsForContract} and
  * {@link getNftsForNftContractIterator} functions.
  *
  * This interface is used to fetch NFTs with their associated metadata. To get
@@ -496,7 +496,7 @@ export interface GetNftsForContractOptions {
 }
 
 /**
- * Optional parameters object for the {@link getNftsForNftContract} and
+ * Optional parameters object for the {@link getNftsForContract} and
  * {@link getNftsForNftContractIterator} functions.
  *
  * This interface is used to fetch NFTs without their associated metadata. To
@@ -516,7 +516,7 @@ export interface GetBaseNftsForContractOptions {
 }
 
 /**
- * The response object for the {@link getNftsForNftContract} function. The object
+ * The response object for the {@link getNftsForContract} function. The object
  * contains the NFTs without metadata inside the NFT contract.
  *
  * @public
@@ -533,7 +533,7 @@ export interface NftContractBaseNftsResponse {
 }
 
 /**
- * The response object for the {@link getNftsForNftContract} function. The object
+ * The response object for the {@link getNftsForContract} function. The object
  * contains the NFTs with metadata inside the NFT contract.
  *
  * @public

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -359,7 +359,7 @@ export interface GetOwnersForNftResponse {
  *
  * @public
  */
-export interface GetOwnersForNftContractResponse {
+export interface GetOwnersForContractResponse {
   /** An array of owner addresses for the provided contract address */
   readonly owners: string[];
 }
@@ -407,7 +407,7 @@ export interface GetNftFloorPriceResponse {
 }
 
 /** The refresh result response object returned by {@link refreshNftContract}. */
-export interface RefreshNftContractResult {
+export interface RefreshContractResult {
   /** The NFT contract address that was passed in to be refreshed. */
   contractAddress: string;
 
@@ -480,11 +480,11 @@ export interface RawContract {
  * {@link getNftsForNftContractIterator} functions.
  *
  * This interface is used to fetch NFTs with their associated metadata. To get
- * Nfts without their associated metadata, use {@link GetBaseNftsForNftContractOptions}.
+ * Nfts without their associated metadata, use {@link GetBaseNftsForContractOptions}.
  *
  * @public
  */
-export interface GetNftsForNftContractOptions {
+export interface GetNftsForContractOptions {
   /**
    * Optional page key from an existing {@link NftContractBaseNftsResponse} or
    * {@link NftContractNftsResponse}to use for pagination.
@@ -500,11 +500,11 @@ export interface GetNftsForNftContractOptions {
  * {@link getNftsForNftContractIterator} functions.
  *
  * This interface is used to fetch NFTs without their associated metadata. To
- * get Nfts with their associated metadata, use {@link GetNftsForNftContractOptions}.
+ * get Nfts with their associated metadata, use {@link GetNftsForContractOptions}.
  *
  * @public
  */
-export interface GetBaseNftsForNftContractOptions {
+export interface GetBaseNftsForContractOptions {
   /**
    * Optional page key from an existing {@link NftContractBaseNftsResponse} or
    * {@link NftContractNftsResponse}to use for pagination.

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -74,7 +74,10 @@ describe('E2E integration tests', () => {
       omitMetadata: true
     });
     console.log('nfts', nfts);
-    const owners = await alchemy.nft.getOwnersForNft(nfts.ownedNfts[0]);
+    const owners = await alchemy.nft.getOwnersForNft(
+      nfts.ownedNfts[0].contract.address,
+      nfts.ownedNfts[0].tokenId
+    );
     console.log('owner', owners);
   });
 
@@ -167,7 +170,7 @@ describe('E2E integration tests', () => {
     await alchemy.nft.refreshNftMetadata(contractAddress, tokenId);
 
     const nft = await alchemy.nft.getNftMetadata(contractAddress, tokenId);
-    await alchemy.nft.refreshNftMetadata(nft);
+    await alchemy.nft.refreshNftMetadata(nft.contract.address, nft.tokenId);
   });
 
   it('refreshNftContract()', async () => {
@@ -213,7 +216,7 @@ describe('E2E integration tests', () => {
         }
       )) {
         await alchemy.nft
-          .getOwnersForNft(nft)
+          .getOwnersForNft(nft.contract.address, nft.tokenId)
           .then(response =>
             console.log('owners:', response.owners, 'tokenId:', nft.tokenId)
           );

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -49,7 +49,7 @@ describe('E2E integration tests', () => {
     console.log(await provider.getBlockNumber());
     const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
     const tokenId = 403;
-    const response = await alchemy.getNftMetadata(
+    const response = await alchemy.nft.getNftMetadata(
       contractAddress,
       tokenId,
       NftTokenType.UNKNOWN
@@ -61,40 +61,43 @@ describe('E2E integration tests', () => {
   it('getOwnersForNft', async () => {
     const tokenId =
       '0x00000000000000000000000000000000000000000000000000000000008b57f0';
-    const response = await alchemy.getOwnersForNft(contractAddress, tokenId);
+    const response = await alchemy.nft.getOwnersForNft(
+      contractAddress,
+      tokenId
+    );
     console.log('res', response);
   });
 
   it('getOwnersForNft from NFT', async () => {
-    const nfts = await alchemy.getNftsForOwner(ownerAddress, {
+    const nfts = await alchemy.nft.getNftsForOwner(ownerAddress, {
       excludeFilters: [NftExcludeFilters.SPAM],
       omitMetadata: true
     });
     console.log('nfts', nfts);
-    const owners = await alchemy.getOwnersForNft(nfts.ownedNfts[0]);
+    const owners = await alchemy.nft.getOwnersForNft(nfts.ownedNfts[0]);
     console.log('owner', owners);
   });
 
   it('getNftsForOwner()', async () => {
-    const nfts = await alchemy.getNftsForOwner('vitalik.eth');
+    const nfts = await alchemy.nft.getNftsForOwner('vitalik.eth');
     console.log('owner', nfts);
   });
 
   it('getNftsForOwner() spam check', async () => {
-    const withSpam = await alchemy.getNftsForOwner('vitalik.eth');
-    const noSpam = await alchemy.getNftsForOwner('vitalik.eth', {
+    const withSpam = await alchemy.nft.getNftsForOwner('vitalik.eth');
+    const noSpam = await alchemy.nft.getNftsForOwner('vitalik.eth', {
       excludeFilters: [NftExcludeFilters.SPAM]
     });
     expect(withSpam.totalCount).not.toEqual(noSpam.totalCount);
   });
 
   it('getOwnersForNftContract', async () => {
-    const owners = await alchemy.getOwnersForNftContract(contractAddress);
+    const owners = await alchemy.nft.getOwnersForNftContract(contractAddress);
     console.log('owners', owners);
   });
 
   it('getNftsForNftContract with pageKey', async () => {
-    let nftsForNftContract = await alchemy.getNftsForNftContract(
+    let nftsForNftContract = await alchemy.nft.getNftsForNftContract(
       contractAddress
     );
 
@@ -103,9 +106,12 @@ describe('E2E integration tests', () => {
       nftsForNftContract.pageKey,
       nftsForNftContract.nfts.length
     );
-    nftsForNftContract = await alchemy.getNftsForNftContract(contractAddress, {
-      pageKey: nftsForNftContract.pageKey
-    });
+    nftsForNftContract = await alchemy.nft.getNftsForNftContract(
+      contractAddress,
+      {
+        pageKey: nftsForNftContract.pageKey
+      }
+    );
     console.log(
       'nftsForNftContract: ',
       nftsForNftContract.pageKey,
@@ -118,7 +124,7 @@ describe('E2E integration tests', () => {
     console.log('lets paginate');
     const allNfts = [];
     let totalCount = 0;
-    for await (const nft of alchemy.getNftsForOwnerIterator(ownerAddress)) {
+    for await (const nft of alchemy.nft.getNftsForOwnerIterator(ownerAddress)) {
       if (totalCount === 10) {
         break;
       }
@@ -126,7 +132,7 @@ describe('E2E integration tests', () => {
       totalCount += 1;
     }
 
-    for await (const nft of alchemy.getNftsForOwnerIterator(ownerAddress, {
+    for await (const nft of alchemy.nft.getNftsForOwnerIterator(ownerAddress, {
       omitMetadata: false
     })) {
       if (totalCount === 10) {
@@ -143,7 +149,7 @@ describe('E2E integration tests', () => {
     console.log('lets paginate');
     const allNfts = [];
     let totalCount = 0;
-    for await (const nft of alchemy.getNftsForNftContractIterator(
+    for await (const nft of alchemy.nft.getNftsForNftContractIterator(
       contractAddress,
       {
         omitMetadata: false
@@ -161,34 +167,39 @@ describe('E2E integration tests', () => {
   it('refreshNftMetadata()', async () => {
     const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
     const tokenId = '404';
-    await alchemy.refreshNftMetadata(contractAddress, tokenId);
+    await alchemy.nft.refreshNftMetadata(contractAddress, tokenId);
 
-    const nft = await alchemy.getNftMetadata(contractAddress, tokenId);
-    await alchemy.refreshNftMetadata(nft);
+    const nft = await alchemy.nft.getNftMetadata(contractAddress, tokenId);
+    await alchemy.nft.refreshNftMetadata(nft);
   });
 
   it('refreshNftContract()', async () => {
     const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
-    const result = await alchemy.refreshNftContract(contractAddress);
+    const result = await alchemy.nft.refreshNftContract(contractAddress);
     console.log('result', result);
   });
 
   describe('README examples', () => {
     it('Example 1: Getting the Nfts owned by an address', async () => {
-      void alchemy.getNftsForOwner('0xshah.eth').then(nfts => {
+      void alchemy.nft.getNftsForOwner('0xshah.eth').then(nfts => {
         console.log(nfts.totalCount);
       });
 
       // Get all the image urls for all the NFTs an address owns.
-      for await (const nft of alchemy.getNftsForOwnerIterator('0xshah.eth')) {
+      for await (const nft of alchemy.nft.getNftsForOwnerIterator(
+        '0xshah.eth'
+      )) {
         console.log(nft.media);
         console.log('done', nft);
       }
 
       // Filter out spam NFTs.
-      for await (const nft of alchemy.getNftsForOwnerIterator('0xshah.eth', {
-        excludeFilters: [NftExcludeFilters.SPAM]
-      })) {
+      for await (const nft of alchemy.nft.getNftsForOwnerIterator(
+        '0xshah.eth',
+        {
+          excludeFilters: [NftExcludeFilters.SPAM]
+        }
+      )) {
         console.log(nft.media);
       }
     });
@@ -197,14 +208,14 @@ describe('E2E integration tests', () => {
       // Bored Ape Yacht Club contract address.
       const baycAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
 
-      for await (const nft of alchemy.getNftsForNftContractIterator(
+      for await (const nft of alchemy.nft.getNftsForNftContractIterator(
         baycAddress,
         {
           // Omit the NFT metadata for smaller payloads.
           omitMetadata: true
         }
       )) {
-        await alchemy
+        await alchemy.nft
           .getOwnersForNft(nft)
           .then(response =>
             console.log('owners:', response.owners, 'tokenId:', nft.tokenId)

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -92,12 +92,12 @@ describe('E2E integration tests', () => {
   });
 
   it('getOwnersForNftContract', async () => {
-    const owners = await alchemy.nft.getOwnersForNftContract(contractAddress);
+    const owners = await alchemy.nft.getOwnersForContract(contractAddress);
     console.log('owners', owners);
   });
 
   it('getNftsForNftContract with pageKey', async () => {
-    let nftsForNftContract = await alchemy.nft.getNftsForNftContract(
+    let nftsForNftContract = await alchemy.nft.getNftsForContract(
       contractAddress
     );
 
@@ -106,12 +106,9 @@ describe('E2E integration tests', () => {
       nftsForNftContract.pageKey,
       nftsForNftContract.nfts.length
     );
-    nftsForNftContract = await alchemy.nft.getNftsForNftContract(
-      contractAddress,
-      {
-        pageKey: nftsForNftContract.pageKey
-      }
-    );
+    nftsForNftContract = await alchemy.nft.getNftsForContract(contractAddress, {
+      pageKey: nftsForNftContract.pageKey
+    });
     console.log(
       'nftsForNftContract: ',
       nftsForNftContract.pageKey,
@@ -149,7 +146,7 @@ describe('E2E integration tests', () => {
     console.log('lets paginate');
     const allNfts = [];
     let totalCount = 0;
-    for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+    for await (const nft of alchemy.nft.getNftsForContractIterator(
       contractAddress,
       {
         omitMetadata: false
@@ -175,7 +172,7 @@ describe('E2E integration tests', () => {
 
   it('refreshNftContract()', async () => {
     const contractAddress = '0x0510745d2ca36729bed35c818527c4485912d99e';
-    const result = await alchemy.nft.refreshNftContract(contractAddress);
+    const result = await alchemy.nft.refreshContract(contractAddress);
     console.log('result', result);
   });
 
@@ -208,7 +205,7 @@ describe('E2E integration tests', () => {
       // Bored Ape Yacht Club contract address.
       const baycAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
 
-      for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+      for await (const nft of alchemy.nft.getNftsForContractIterator(
         baycAddress,
         {
           // Omit the NFT metadata for smaller payloads.

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -600,7 +600,7 @@ describe('NFT module', () => {
       'called with the correct parameters',
       async (mockResponse, omitMetadata, expectedWithMetadata) => {
         mock.onGet().reply(200, mockResponse);
-        await alchemy.nft.getNftsForNftContract(contractAddress, {
+        await alchemy.nft.getNftsForContract(contractAddress, {
           pageKey,
           omitMetadata
         });
@@ -645,13 +645,10 @@ describe('NFT module', () => {
       'normalizes responses',
       async (omitMetadata, mockResponse, expected) => {
         mock.onGet().reply(200, mockResponse);
-        const response = await alchemy.nft.getNftsForNftContract(
-          contractAddress,
-          {
-            pageKey,
-            omitMetadata
-          }
-        );
+        const response = await alchemy.nft.getNftsForContract(contractAddress, {
+          pageKey,
+          omitMetadata
+        });
         expect(response).toEqual(expected);
       }
     );
@@ -660,7 +657,7 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
       await expect(
-        alchemy.nft.getNftsForNftContract(contractAddress, {
+        alchemy.nft.getNftsForContract(contractAddress, {
           omitMetadata
         })
       ).rejects.toThrow('Internal Server Error');
@@ -668,7 +665,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       mock.onGet().reply(200, nftResponse);
-      const response = await alchemy.nft.getNftsForNftContract(contractAddress);
+      const response = await alchemy.nft.getNftsForContract(contractAddress);
       response.nfts.forEach(nft => expect(nft.media).toBeDefined());
     });
   });
@@ -732,7 +729,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata, expectedWithMetadata) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+        for await (const nft of alchemy.nft.getNftsForContractIterator(
           contractAddress,
           {
             omitMetadata
@@ -766,7 +763,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+        for await (const nft of alchemy.nft.getNftsForContractIterator(
           contractAddress,
           {
             pageKey,
@@ -816,7 +813,7 @@ describe('NFT module', () => {
       async (omitMetadata, mockResponses, expected) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const ownedNft of alchemy.nft.getNftsForNftContractIterator(
+        for await (const ownedNft of alchemy.nft.getNftsForContractIterator(
           contractAddress,
           {
             omitMetadata
@@ -839,7 +836,7 @@ describe('NFT module', () => {
           .replyOnce(500, 'Internal Server Error');
         const tokenIds: string[] = [];
         try {
-          for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+          for await (const nft of alchemy.nft.getNftsForContractIterator(
             contractAddress,
             {
               omitMetadata
@@ -857,7 +854,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       setupMock(nftResponses);
-      for await (const nft of alchemy.nft.getNftsForNftContractIterator(
+      for await (const nft of alchemy.nft.getNftsForContractIterator(
         contractAddress
       )) {
         expect(nft.media).toBeDefined();
@@ -935,7 +932,7 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.nft.getOwnersForNftContract(contractAddress);
+      await alchemy.nft.getOwnersForContract(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -944,7 +941,7 @@ describe('NFT module', () => {
     });
 
     it('can be called with BaseNft', async () => {
-      const response = await alchemy.nft.getOwnersForNftContract(
+      const response = await alchemy.nft.getOwnersForContract(
         createBaseNft(contractAddress, tokenIdHex)
       );
       expect(mock.history.get.length).toEqual(1);
@@ -1023,7 +1020,7 @@ describe('NFT module', () => {
     const spamContract = '0x000440f08436a7b866d1ae42db5e0be801da722a';
     it('calls with the correct parameters', async () => {
       mock.onGet().reply(200, true);
-      await alchemy.nft.isSpamNftContract(spamContract);
+      await alchemy.nft.isSpamContract(spamContract);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1035,7 +1032,7 @@ describe('NFT module', () => {
   describe('getSpamNftContracts', () => {
     it('calls with the correct parameters', async () => {
       mock.onGet().reply(200, ['0xABC', '0xABD']);
-      await alchemy.nft.getSpamNftContracts();
+      await alchemy.nft.getSpamContracts();
       expect(mock.history.get.length).toEqual(1);
     });
   });
@@ -1063,7 +1060,7 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.nft.getNftFloorPrice(contractAddress);
+      await alchemy.nft.getFloorPrice(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1075,17 +1072,17 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(429, 'Too many requests');
 
-      await expect(
-        alchemy.nft.getNftFloorPrice(contractAddress)
-      ).rejects.toThrow('Too many requests');
+      await expect(alchemy.nft.getFloorPrice(contractAddress)).rejects.toThrow(
+        'Too many requests'
+      );
     });
 
     it('surfaces errors', async () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
-      await expect(
-        alchemy.nft.getNftFloorPrice(contractAddress)
-      ).rejects.toThrow('Internal Server Error');
+      await expect(alchemy.nft.getFloorPrice(contractAddress)).rejects.toThrow(
+        'Internal Server Error'
+      );
     });
   });
 
@@ -1205,7 +1202,7 @@ describe('NFT module', () => {
       mock.onGet().reply(200, refreshResponse);
     });
     it('calls with the correct parameters', async () => {
-      const response = await alchemy.nft.refreshNftContract(contractAddress);
+      const response = await alchemy.nft.refreshContract(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1219,7 +1216,7 @@ describe('NFT module', () => {
     });
 
     it('can be called with BaseNft', async () => {
-      const response = await alchemy.nft.refreshNftContract(
+      const response = await alchemy.nft.refreshContract(
         createBaseNft(contractAddress, '0x42')
       );
       expect(mock.history.get.length).toEqual(1);
@@ -1240,7 +1237,7 @@ describe('NFT module', () => {
       mock.onGet().reply(429, 'Too many requests');
 
       await expect(
-        alchemy.nft.refreshNftContract(contractAddress)
+        alchemy.nft.refreshContract(contractAddress)
       ).rejects.toThrow('Too many requests');
     });
   });

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -4,7 +4,7 @@ import {
   NftContractBaseNftsResponse,
   NftContractNftsResponse,
   fromHex,
-  GetNftFloorPriceResponse,
+  GetFloorPriceResponse,
   GetNftsForOwnerOptions,
   NftContract,
   NftExcludeFilters,
@@ -20,7 +20,6 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {
   createBaseNft,
-  createBaseNftContract,
   createNft,
   createOwnedBaseNft,
   createOwnedNft,
@@ -99,19 +98,6 @@ describe('NFT module', () => {
       );
     }
 
-    it('can be called with a BaseNftContract', async () => {
-      const nftContract = createBaseNftContract(address);
-      verifyNftContractMetadata(
-        await alchemy.nft.getNftContractMetadata(nftContract),
-        expectedNftContract,
-        address,
-        name,
-        symbol,
-        totalSupply,
-        tokenType
-      );
-    });
-
     it('can be called with raw parameters', async () => {
       verifyNftContractMetadata(
         await alchemy.nft.getNftContractMetadata(address),
@@ -166,17 +152,6 @@ describe('NFT module', () => {
         tokenType ?? undefined
       );
     }
-
-    it('can be called with a BaseNft', async () => {
-      const nft = createBaseNft(contractAddress, tokenId, NftTokenType.ERC721);
-      verifyNftMetadata(
-        await alchemy.nft.getNftMetadata(nft),
-        expectedNft,
-        contractAddress,
-        tokenId,
-        NftTokenType.ERC721
-      );
-    });
 
     it('can be called with raw parameters', async () => {
       verifyNftMetadata(
@@ -886,21 +861,9 @@ describe('NFT module', () => {
         tokenIdNumber
       );
 
-      await alchemy.nft.getOwnersForNft(contractAddress, tokenIdNumber);
-      expect(mock.history.get[0].params).toHaveProperty(
-        'tokenId',
-        tokenIdNumber
-      );
-    });
-
-    it('can be called with BaseNft', async () => {
       const response = await alchemy.nft.getOwnersForNft(
-        createBaseNft(contractAddress, tokenIdHex)
-      );
-      expect(mock.history.get.length).toEqual(1);
-      expect(mock.history.get[0].params).toHaveProperty(
-        'contractAddress',
-        contractAddress
+        contractAddress,
+        tokenIdNumber
       );
       expect(mock.history.get[0].params).toHaveProperty(
         'tokenId',
@@ -932,24 +895,12 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.nft.getOwnersForContract(contractAddress);
+      const response = await alchemy.nft.getOwnersForContract(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
         contractAddress
       );
-    });
-
-    it('can be called with BaseNft', async () => {
-      const response = await alchemy.nft.getOwnersForContract(
-        createBaseNft(contractAddress, tokenIdHex)
-      );
-      expect(mock.history.get.length).toEqual(1);
-      expect(mock.history.get[0].params).toHaveProperty(
-        'contractAddress',
-        contractAddress
-      );
-
       expect(response).toEqual({ owners });
     });
 
@@ -1039,7 +990,7 @@ describe('NFT module', () => {
 
   describe('getNftFloorPrice', () => {
     const contractAddress = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d';
-    const templateResponse: GetNftFloorPriceResponse = {
+    const templateResponse: GetFloorPriceResponse = {
       openSea: {
         floorPrice: 90.969,
         priceCurrency: 'ETH',
@@ -1147,13 +1098,6 @@ describe('NFT module', () => {
       useRefreshTrue();
     });
 
-    it('can be called with a BaseNft', async () => {
-      await alchemy.nft.refreshNftMetadata(
-        createBaseNft(contractAddress, tokenIdHex)
-      );
-      verifyCorrectParams();
-    });
-
     it('can be called with raw parameters', async () => {
       const res = await alchemy.nft.refreshNftMetadata(
         contractAddress,
@@ -1208,23 +1152,6 @@ describe('NFT module', () => {
         'contractAddress',
         contractAddress
       );
-      expect(response).toEqual({
-        contractAddress,
-        refreshState: RefreshState.QUEUED,
-        progress: '5'
-      });
-    });
-
-    it('can be called with BaseNft', async () => {
-      const response = await alchemy.nft.refreshContract(
-        createBaseNft(contractAddress, '0x42')
-      );
-      expect(mock.history.get.length).toEqual(1);
-      expect(mock.history.get[0].params).toHaveProperty(
-        'contractAddress',
-        contractAddress
-      );
-
       expect(response).toEqual({
         contractAddress,
         refreshState: RefreshState.QUEUED,

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -102,7 +102,7 @@ describe('NFT module', () => {
     it('can be called with a BaseNftContract', async () => {
       const nftContract = createBaseNftContract(address);
       verifyNftContractMetadata(
-        await alchemy.getNftContractMetadata(nftContract),
+        await alchemy.nft.getNftContractMetadata(nftContract),
         expectedNftContract,
         address,
         name,
@@ -114,7 +114,7 @@ describe('NFT module', () => {
 
     it('can be called with raw parameters', async () => {
       verifyNftContractMetadata(
-        await alchemy.getNftContractMetadata(address),
+        await alchemy.nft.getNftContractMetadata(address),
         expectedNftContract,
         address,
         name,
@@ -127,7 +127,7 @@ describe('NFT module', () => {
     it('surfaces errors', async () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
-      await expect(alchemy.getNftContractMetadata(address)).rejects.toThrow(
+      await expect(alchemy.nft.getNftContractMetadata(address)).rejects.toThrow(
         'Internal Server Error'
       );
     });
@@ -170,7 +170,7 @@ describe('NFT module', () => {
     it('can be called with a BaseNft', async () => {
       const nft = createBaseNft(contractAddress, tokenId, NftTokenType.ERC721);
       verifyNftMetadata(
-        await alchemy.getNftMetadata(nft),
+        await alchemy.nft.getNftMetadata(nft),
         expectedNft,
         contractAddress,
         tokenId,
@@ -180,7 +180,7 @@ describe('NFT module', () => {
 
     it('can be called with raw parameters', async () => {
       verifyNftMetadata(
-        await alchemy.getNftMetadata(
+        await alchemy.nft.getNftMetadata(
           contractAddress,
           tokenId,
           NftTokenType.ERC1155
@@ -194,7 +194,7 @@ describe('NFT module', () => {
 
     it('normalizes tokenId as a hex string', async () => {
       verifyNftMetadata(
-        await alchemy.getNftMetadata(
+        await alchemy.nft.getNftMetadata(
           contractAddress,
           tokenId,
           NftTokenType.ERC1155
@@ -208,7 +208,7 @@ describe('NFT module', () => {
 
     it('sets tokenType to undefined if tokenType is UNKNOWN', async () => {
       verifyNftMetadata(
-        await alchemy.getNftMetadata(
+        await alchemy.nft.getNftMetadata(
           contractAddress,
           tokenId,
           NftTokenType.UNKNOWN
@@ -223,7 +223,7 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
       await expect(
-        alchemy.getNftMetadata(contractAddress, tokenId)
+        alchemy.nft.getNftMetadata(contractAddress, tokenId)
       ).rejects.toThrow('Internal Server Error');
     });
   });
@@ -266,7 +266,7 @@ describe('NFT module', () => {
       'called with the correct parameters',
       async (omitMetadata, expectedWithMetadata) => {
         mock.onGet().reply(200, nftResponse);
-        await alchemy.getNftsForOwner(ownerAddress, {
+        await alchemy.nft.getNftsForOwner(ownerAddress, {
           ...getNftsParams,
           omitMetadata
         });
@@ -321,7 +321,7 @@ describe('NFT module', () => {
       'normalizes fields in response',
       async (omitMetadata, rawResponse, expected) => {
         mock.onGet().reply(200, rawResponse);
-        const response = await alchemy.getNftsForOwner(ownerAddress, {
+        const response = await alchemy.nft.getNftsForOwner(ownerAddress, {
           ...getNftsParams,
           omitMetadata
         });
@@ -333,7 +333,7 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
       await expect(
-        alchemy.getNftsForOwner(ownerAddress, {
+        alchemy.nft.getNftsForOwner(ownerAddress, {
           ...getNftsParams,
           omitMetadata
         })
@@ -342,7 +342,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       mock.onGet().reply(200, nftResponse);
-      const response = await alchemy.getNftsForOwner(ownerAddress);
+      const response = await alchemy.nft.getNftsForOwner(ownerAddress);
       response.ownedNfts.forEach(nft => expect(nft.media).toBeDefined());
     });
   });
@@ -411,7 +411,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata, expectedWithMetadata) => {
         setupMock(mockResponses);
         const ownedNfts = [];
-        for await (const ownedNft of alchemy.getNftsForOwnerIterator(
+        for await (const ownedNft of alchemy.nft.getNftsForOwnerIterator(
           ownerAddress,
           {
             excludeFilters,
@@ -464,7 +464,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata) => {
         setupMock(mockResponses);
         const ownedNfts = [];
-        for await (const ownedNft of alchemy.getNftsForOwnerIterator(
+        for await (const ownedNft of alchemy.nft.getNftsForOwnerIterator(
           ownerAddress,
           {
             pageKey: 'page-key0',
@@ -511,7 +511,7 @@ describe('NFT module', () => {
       async (omitMetadata, mockResponses, expected) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const ownedNft of alchemy.getNftsForOwnerIterator(
+        for await (const ownedNft of alchemy.nft.getNftsForOwnerIterator(
           ownerAddress,
           {
             contractAddresses,
@@ -536,7 +536,7 @@ describe('NFT module', () => {
 
         const tokenIds: number[] = [];
         try {
-          for await (const ownedNft of alchemy.getNftsForOwnerIterator(
+          for await (const ownedNft of alchemy.nft.getNftsForOwnerIterator(
             ownerAddress,
             {
               omitMetadata
@@ -554,7 +554,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       setupMock(nftResponses);
-      for await (const ownedNft of alchemy.getNftsForOwnerIterator(
+      for await (const ownedNft of alchemy.nft.getNftsForOwnerIterator(
         ownerAddress
       )) {
         expect(ownedNft.media).toBeDefined();
@@ -600,7 +600,7 @@ describe('NFT module', () => {
       'called with the correct parameters',
       async (mockResponse, omitMetadata, expectedWithMetadata) => {
         mock.onGet().reply(200, mockResponse);
-        await alchemy.getNftsForNftContract(contractAddress, {
+        await alchemy.nft.getNftsForNftContract(contractAddress, {
           pageKey,
           omitMetadata
         });
@@ -645,10 +645,13 @@ describe('NFT module', () => {
       'normalizes responses',
       async (omitMetadata, mockResponse, expected) => {
         mock.onGet().reply(200, mockResponse);
-        const response = await alchemy.getNftsForNftContract(contractAddress, {
-          pageKey,
-          omitMetadata
-        });
+        const response = await alchemy.nft.getNftsForNftContract(
+          contractAddress,
+          {
+            pageKey,
+            omitMetadata
+          }
+        );
         expect(response).toEqual(expected);
       }
     );
@@ -657,7 +660,7 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
       await expect(
-        alchemy.getNftsForNftContract(contractAddress, {
+        alchemy.nft.getNftsForNftContract(contractAddress, {
           omitMetadata
         })
       ).rejects.toThrow('Internal Server Error');
@@ -665,7 +668,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       mock.onGet().reply(200, nftResponse);
-      const response = await alchemy.getNftsForNftContract(contractAddress);
+      const response = await alchemy.nft.getNftsForNftContract(contractAddress);
       response.nfts.forEach(nft => expect(nft.media).toBeDefined());
     });
   });
@@ -729,7 +732,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata, expectedWithMetadata) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const nft of alchemy.getNftsForNftContractIterator(
+        for await (const nft of alchemy.nft.getNftsForNftContractIterator(
           contractAddress,
           {
             omitMetadata
@@ -763,7 +766,7 @@ describe('NFT module', () => {
       async (mockResponses, omitMetadata) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const nft of alchemy.getNftsForNftContractIterator(
+        for await (const nft of alchemy.nft.getNftsForNftContractIterator(
           contractAddress,
           {
             pageKey,
@@ -813,7 +816,7 @@ describe('NFT module', () => {
       async (omitMetadata, mockResponses, expected) => {
         setupMock(mockResponses);
         const nfts = [];
-        for await (const ownedNft of alchemy.getNftsForNftContractIterator(
+        for await (const ownedNft of alchemy.nft.getNftsForNftContractIterator(
           contractAddress,
           {
             omitMetadata
@@ -836,7 +839,7 @@ describe('NFT module', () => {
           .replyOnce(500, 'Internal Server Error');
         const tokenIds: string[] = [];
         try {
-          for await (const nft of alchemy.getNftsForNftContractIterator(
+          for await (const nft of alchemy.nft.getNftsForNftContractIterator(
             contractAddress,
             {
               omitMetadata
@@ -854,7 +857,7 @@ describe('NFT module', () => {
 
     it('uses the correct overload with no options', async () => {
       setupMock(nftResponses);
-      for await (const nft of alchemy.getNftsForNftContractIterator(
+      for await (const nft of alchemy.nft.getNftsForNftContractIterator(
         contractAddress
       )) {
         expect(nft.media).toBeDefined();
@@ -875,7 +878,7 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.getOwnersForNft(contractAddress, tokenIdHex);
+      await alchemy.nft.getOwnersForNft(contractAddress, tokenIdHex);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -886,7 +889,7 @@ describe('NFT module', () => {
         tokenIdNumber
       );
 
-      await alchemy.getOwnersForNft(contractAddress, tokenIdNumber);
+      await alchemy.nft.getOwnersForNft(contractAddress, tokenIdNumber);
       expect(mock.history.get[0].params).toHaveProperty(
         'tokenId',
         tokenIdNumber
@@ -894,7 +897,7 @@ describe('NFT module', () => {
     });
 
     it('can be called with BaseNft', async () => {
-      const response = await alchemy.getOwnersForNft(
+      const response = await alchemy.nft.getOwnersForNft(
         createBaseNft(contractAddress, tokenIdHex)
       );
       expect(mock.history.get.length).toEqual(1);
@@ -915,7 +918,7 @@ describe('NFT module', () => {
       mock.onGet().reply(429, 'Too many requests');
 
       await expect(
-        alchemy.getOwnersForNft(contractAddress, tokenIdHex)
+        alchemy.nft.getOwnersForNft(contractAddress, tokenIdHex)
       ).rejects.toThrow('Too many requests');
     });
   });
@@ -932,7 +935,7 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.getOwnersForNftContract(contractAddress);
+      await alchemy.nft.getOwnersForNftContract(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -941,7 +944,7 @@ describe('NFT module', () => {
     });
 
     it('can be called with BaseNft', async () => {
-      const response = await alchemy.getOwnersForNftContract(
+      const response = await alchemy.nft.getOwnersForNftContract(
         createBaseNft(contractAddress, tokenIdHex)
       );
       expect(mock.history.get.length).toEqual(1);
@@ -958,7 +961,7 @@ describe('NFT module', () => {
       mock.onGet().reply(429, 'Too many requests');
 
       await expect(
-        alchemy.getOwnersForNft(contractAddress, tokenIdHex)
+        alchemy.nft.getOwnersForNft(contractAddress, tokenIdHex)
       ).rejects.toThrow('Too many requests');
     });
   });
@@ -980,7 +983,7 @@ describe('NFT module', () => {
 
     it('calls with the correct parameters', async () => {
       mock.onGet().reply(200, emptyResponse);
-      await alchemy.checkNftOwnership(owner, addresses);
+      await alchemy.nft.checkNftOwnership(owner, addresses);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty('owner', owner);
       expect(mock.history.get[0].params).toHaveProperty(
@@ -991,7 +994,7 @@ describe('NFT module', () => {
     });
 
     it('throws if no contract address is passed in', async () => {
-      await expect(alchemy.checkNftOwnership(owner, [])).rejects.toThrow(
+      await expect(alchemy.nft.checkNftOwnership(owner, [])).rejects.toThrow(
         'Must provide at least one contract address'
       );
     });
@@ -1004,15 +1007,15 @@ describe('NFT module', () => {
       'returns the correct response',
       async (response, expected) => {
         mock.onGet().reply(200, response);
-        const result = await alchemy.checkNftOwnership(owner, addresses);
+        const result = await alchemy.nft.checkNftOwnership(owner, addresses);
         expect(result).toEqual(expected);
       }
     );
     it('surfaces errors', async () => {
       mock.onGet().reply(500, 'Internal Server Error');
-      await expect(alchemy.checkNftOwnership(owner, addresses)).rejects.toThrow(
-        'Internal Server Error'
-      );
+      await expect(
+        alchemy.nft.checkNftOwnership(owner, addresses)
+      ).rejects.toThrow('Internal Server Error');
     });
   });
 
@@ -1020,7 +1023,7 @@ describe('NFT module', () => {
     const spamContract = '0x000440f08436a7b866d1ae42db5e0be801da722a';
     it('calls with the correct parameters', async () => {
       mock.onGet().reply(200, true);
-      await alchemy.isSpamNftContract(spamContract);
+      await alchemy.nft.isSpamNftContract(spamContract);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1032,7 +1035,7 @@ describe('NFT module', () => {
   describe('getSpamNftContracts', () => {
     it('calls with the correct parameters', async () => {
       mock.onGet().reply(200, ['0xABC', '0xABD']);
-      await alchemy.getSpamNftContracts();
+      await alchemy.nft.getSpamNftContracts();
       expect(mock.history.get.length).toEqual(1);
     });
   });
@@ -1060,7 +1063,7 @@ describe('NFT module', () => {
     });
 
     it('calls with the correct parameters', async () => {
-      await alchemy.getNftFloorPrice(contractAddress);
+      await alchemy.nft.getNftFloorPrice(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1072,17 +1075,17 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(429, 'Too many requests');
 
-      await expect(alchemy.getNftFloorPrice(contractAddress)).rejects.toThrow(
-        'Too many requests'
-      );
+      await expect(
+        alchemy.nft.getNftFloorPrice(contractAddress)
+      ).rejects.toThrow('Too many requests');
     });
 
     it('surfaces errors', async () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
-      await expect(alchemy.getNftFloorPrice(contractAddress)).rejects.toThrow(
-        'Internal Server Error'
-      );
+      await expect(
+        alchemy.nft.getNftFloorPrice(contractAddress)
+      ).rejects.toThrow('Internal Server Error');
     });
   });
 
@@ -1148,27 +1151,36 @@ describe('NFT module', () => {
     });
 
     it('can be called with a BaseNft', async () => {
-      await alchemy.refreshNftMetadata(
+      await alchemy.nft.refreshNftMetadata(
         createBaseNft(contractAddress, tokenIdHex)
       );
       verifyCorrectParams();
     });
 
     it('can be called with raw parameters', async () => {
-      const res = await alchemy.refreshNftMetadata(contractAddress, tokenId);
+      const res = await alchemy.nft.refreshNftMetadata(
+        contractAddress,
+        tokenId
+      );
       expect(res).toBe(true);
       verifyCorrectParams();
     });
 
     it('returns false if metadata was not refreshed', async () => {
       useRefreshFalse();
-      const res = await alchemy.refreshNftMetadata(contractAddress, tokenId);
+      const res = await alchemy.nft.refreshNftMetadata(
+        contractAddress,
+        tokenId
+      );
       expect(res).toBe(false);
       verifyCorrectParams();
     });
 
     it('normalizes tokenId as a hex string', async () => {
-      const res = await alchemy.refreshNftMetadata(contractAddress, tokenIdHex);
+      const res = await alchemy.nft.refreshNftMetadata(
+        contractAddress,
+        tokenIdHex
+      );
       expect(res).toBe(true);
       verifyCorrectParams();
     });
@@ -1177,7 +1189,7 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(500, 'Internal Server Error');
       await expect(
-        alchemy.refreshNftMetadata(contractAddress, tokenId)
+        alchemy.nft.refreshNftMetadata(contractAddress, tokenId)
       ).rejects.toThrow('Internal Server Error');
     });
   });
@@ -1193,7 +1205,7 @@ describe('NFT module', () => {
       mock.onGet().reply(200, refreshResponse);
     });
     it('calls with the correct parameters', async () => {
-      const response = await alchemy.refreshNftContract(contractAddress);
+      const response = await alchemy.nft.refreshNftContract(contractAddress);
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(
         'contractAddress',
@@ -1207,7 +1219,7 @@ describe('NFT module', () => {
     });
 
     it('can be called with BaseNft', async () => {
-      const response = await alchemy.refreshNftContract(
+      const response = await alchemy.nft.refreshNftContract(
         createBaseNft(contractAddress, '0x42')
       );
       expect(mock.history.get.length).toEqual(1);
@@ -1227,9 +1239,9 @@ describe('NFT module', () => {
       mock.reset();
       mock.onGet().reply(429, 'Too many requests');
 
-      await expect(alchemy.refreshNftContract(contractAddress)).rejects.toThrow(
-        'Too many requests'
-      );
+      await expect(
+        alchemy.nft.refreshNftContract(contractAddress)
+      ).rejects.toThrow('Too many requests');
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["dist/**/*", "node_modules/**/*"],
+  "exclude": ["dist/**/*", "node_modules/**/*"]
 }


### PR DESCRIPTION
### Sub-modules Overview
We've received some preliminary feedback that we have too many methods on the top level `Alchemy` class, which makes it harder to discover methods and understand what layer of abstraction each method is one. This PR is another breaking change on the `v1.1.0` base, and separates the methods into the following "modules":
- `nft`: Contains all NFT HTTP API methods + syntactic sugar abstractions
- `ws`: Contains the Subscription API and other WebSocket methods
- `rpc`: Contains the core eth-json rpc methods, based on ethers' API
- `enhanced`: Contains the Enhanced APIs that Alchemy provides, along with any other higher level abstraction methods (ex: `findContractDeployer()`)

Other modules to consider adding in the future: `defi`, `webhooks`, `wallet`, etc.

### PR Changes
- Moved NFT methods into `NftModule`.
- Shorten `NFT` method names since they're in under an `nft` module now
- Removed `BaseNft` overloads in the NFT methods since they add trivial value + add complexity to typing