### PR TITLE
Rename modules to namespaces

### DIFF
--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -6,7 +6,7 @@ import { CoreNamespace } from './core-namespace';
 
 /**
  * The Alchemy SDK client. This class is the main entry point into Alchemy's
- * APIs and separates functionality into different modules.
+ * APIs and separates functionality into different namespaces.
  *
  * Each SDK instance is associated with a specific network and API key. To use a
  * different network or API key, create a new instance of {@link Alchemy}.

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -1,8 +1,8 @@
 import { AlchemySettings } from '../types/types';
-import { NftModule } from './nft-module';
-import { WebSocketModule } from './websocket-module';
+import { NftNamespace } from './nft-namespace';
+import { WebSocketNamespace } from './websocket-namespace';
 import { AlchemyConfig } from './alchemy-config';
-import { CoreModule } from './core-module';
+import { CoreNamespace } from './core-namespace';
 
 /**
  * The Alchemy SDK client. This class is the main entry point into Alchemy's
@@ -14,9 +14,22 @@ import { CoreModule } from './core-module';
  * @public
  */
 export class Alchemy {
-  readonly core: CoreModule;
-  readonly nft: NftModule;
-  readonly ws: WebSocketModule;
+  /**
+   * The `core` namespace contains the core eth json-rpc calls and Alchemy's
+   * Enhanced APIs.
+   */
+  readonly core: CoreNamespace;
+
+  /** The `nft` namespace contains methods for Alchemy's NFT API. */
+  readonly nft: NftNamespace;
+
+  /** The `ws` namespace contains methods for using WebSockets and creating subscriptions. */
+  readonly ws: WebSocketNamespace;
+
+  /**
+   * Holds the setting information for the instance of the Alchemy SDK client
+   * and allows access to the underlying providers.
+   */
   readonly config: AlchemyConfig;
 
   /**
@@ -28,8 +41,8 @@ export class Alchemy {
   constructor(settings?: AlchemySettings) {
     this.config = new AlchemyConfig(settings);
 
-    this.core = new CoreModule(this.config);
-    this.nft = new NftModule(this.config);
-    this.ws = new WebSocketModule(this.config);
+    this.core = new CoreNamespace(this.config);
+    this.nft = new NftNamespace(this.config);
+    this.ws = new WebSocketNamespace(this.config);
   }
 }

--- a/src/api/core-namespace.ts
+++ b/src/api/core-namespace.ts
@@ -19,13 +19,15 @@ import {
   AssetTransfersResponse,
   DeployResult,
   TokenBalancesResponse,
-  TokenMetadataResponse, TransactionReceiptsParams, TransactionReceiptsResponse
+  TokenMetadataResponse,
+  TransactionReceiptsParams,
+  TransactionReceiptsResponse
 } from '../types/types';
 import { DEFAULT_CONTRACT_ADDRESSES, ETH_NULL_VALUE } from '../util/const';
 import { toHex } from './util';
 import { formatBlock } from '../util/util';
 
-export class CoreModule {
+export class CoreNamespace {
   constructor(private readonly config: AlchemyConfig) {}
 
   /**
@@ -436,7 +438,6 @@ export class CoreModule {
   }
 }
 
-
 /**
  * Perform a binary search between an integer range of block numbers to find the
  * block number where the contract was deployed.
@@ -461,4 +462,3 @@ async function binarySearchFirstBlock(
   }
   return binarySearchFirstBlock(start, mid, address, config);
 }
-

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -35,7 +35,7 @@ import {
 } from '../internal/nft-api';
 import { AlchemyConfig } from './alchemy-config';
 
-export class NftModule {
+export class NftNamespace {
   constructor(private readonly config: AlchemyConfig) {}
 
   /**

--- a/src/api/websocket-namespace.ts
+++ b/src/api/websocket-namespace.ts
@@ -2,8 +2,7 @@ import { AlchemyEventType } from '../types/types';
 import type { Listener } from '@ethersproject/abstract-provider';
 import { AlchemyConfig } from './alchemy-config';
 
-export class WebSocketModule {
-  // TODO: Only pass in the provider cuz that's all we need: readability
+export class WebSocketNamespace {
   constructor(private readonly config: AlchemyConfig) {}
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ export type { AlchemyProvider } from './api/alchemy-provider';
 
 export type { AlchemyWebSocketProvider } from './api/alchemy-websocket-provider';
 
-export type { NftModule } from './api/nft-module';
+export type { NftNamespace } from './api/nft-namespace';
 
-export type { WebSocketModule } from './api/websocket-module';
+export type { WebSocketNamespace } from './api/websocket-namespace';
 
 export type { BaseNftContract, NftContract, Nft, BaseNft } from './api/nft';
 

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -38,9 +38,7 @@ describe('E2E integration tests', () => {
 
     // ENS
     contractAddress = '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85';
-    contractDeployer = await alchemy.core.findContractDeployer(
-      contractAddress
-    );
+    contractDeployer = await alchemy.core.findContractDeployer(contractAddress);
     expect(contractDeployer.deployerAddress).toEqual(
       '0x4fe4e666be5752f1fdd210f4ab5de2cc26e3e0e8'
     );


### PR DESCRIPTION
As per our discussion, the term 'namespaces' is more apt than 'modules', which is an overloaded term.