### PR TITLE
Add send() override in AlchemyProvider()

### DIFF
--- a/src/api/core-namespace.ts
+++ b/src/api/core-namespace.ts
@@ -383,10 +383,11 @@ export class CoreNamespace {
       );
     }
     const provider = await this.config.getProvider();
-    return provider.send('alchemy_getTokenBalances', [
-      address,
-      contractAddresses || DEFAULT_CONTRACT_ADDRESSES
-    ]);
+    return provider._send(
+      'alchemy_getTokenBalances',
+      [address, contractAddresses || DEFAULT_CONTRACT_ADDRESSES],
+      'getTokenBalances'
+    );
   }
 
   /**
@@ -397,7 +398,11 @@ export class CoreNamespace {
    */
   async getTokenMetadata(address: string): Promise<TokenMetadataResponse> {
     const provider = await this.config.getProvider();
-    return provider.send('alchemy_getTokenMetadata', [address]);
+    return provider._send(
+      'alchemy_getTokenMetadata',
+      [address],
+      'getTokenMetadata'
+    );
   }
 
   /**
@@ -412,16 +417,22 @@ export class CoreNamespace {
     params: AssetTransfersParams
   ): Promise<AssetTransfersResponse> {
     const provider = await this.config.getProvider();
-    return provider.send('alchemy_getAssetTransfers', [
-      {
-        ...params,
-        fromBlock:
-          params.fromBlock != null ? formatBlock(params.fromBlock) : undefined,
-        toBlock:
-          params.toBlock != null ? formatBlock(params.toBlock) : undefined,
-        maxCount: params.maxCount != null ? toHex(params.maxCount) : undefined
-      }
-    ]);
+    return provider._send(
+      'alchemy_getAssetTransfers',
+      [
+        {
+          ...params,
+          fromBlock:
+            params.fromBlock != null
+              ? formatBlock(params.fromBlock)
+              : undefined,
+          toBlock:
+            params.toBlock != null ? formatBlock(params.toBlock) : undefined,
+          maxCount: params.maxCount != null ? toHex(params.maxCount) : undefined
+        }
+      ],
+      'getAssetTransfers'
+    );
   }
 
   /**
@@ -434,7 +445,11 @@ export class CoreNamespace {
     params: TransactionReceiptsParams
   ): Promise<TransactionReceiptsResponse> {
     const provider = await this.config.getProvider();
-    return provider.send('alchemy_getTransactionReceipts', [params]);
+    return provider._send(
+      'alchemy_getTransactionReceipts',
+      [params],
+      'getTransactionReceipts'
+    );
   }
 }
 

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -226,7 +226,8 @@ describe('E2E integration tests', () => {
     });
 
     it('Example 3: Token balances', async () => {
-      await alchemy.core.getTokenBalances(ownerAddress).then(console.log);
+      // await alchemy.core.getTokenBalances(ownerAddress).then(console.log);
+      await alchemy.core.getBalance('0xshah.eth').then(console.log);
     });
   });
 });


### PR DESCRIPTION
This PR adds the method header for Enhanced APIs and `send()`. This is not the most optimal since this doesn't allow tracking some core namespace calls, but opens the door for a future refactor.

Changes:
- copy over `JsonRpcProvider.send()` as `_send()` in order to add add header into the `ConnectionInfo` (this avoids needing to copy everything in the `fetchJson()` chain of calls.
- fix a bug where providing the URL doesn't pass in the network

todo for another PR:
- we can get more accurate method headers by overriding `perform()` to pass the method header, but we can postpone that until we need to capture method headers for one of those methods.

Tested manually and verified that headers are landing in imply.