### PR TITLE
Add the `pageSize` parameter for getNftsForContract()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Removed the deprecated `TOKEN` enum from `AssetTransfersCategory`.
 - Added support for Optimism Goerli network via the `Network.OPT_GOERLI` enum.
 - Added the `transact` namespace for functionality relating to sending transactions. This includes the Flashbots methods `sendPrivateTransaction` and `cancelPrivateTransaction`.
-- Added the `limit` parameter in `GetNftsForContractOption` for use with `alchemy.nft.getNftsForContract`.
+- Added the `pageSize` parameter in `GetNftsForContractOption` to specify the number of NFTs fetched when using `alchemy.nft.getNftsForContract`.
 
 
 ## 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Removed the deprecated `TOKEN` enum from `AssetTransfersCategory`.
 - Added support for Optimism Goerli network via the `Network.OPT_GOERLI` enum.
 - Added the `transact` namespace for functionality relating to sending transactions. This includes the Flashbots methods `sendPrivateTransaction` and `cancelPrivateTransaction`.
+- Added the `limit` parameter in `GetNftsForContractOption` for use with `alchemy.nft.getNftsForContract`.
 
 
 ## 2.0.1

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -151,7 +151,8 @@ export async function getNftsForContract(
   >(config, AlchemyApiType.NFT, 'getNFTsForCollection', srcMethod, {
     contractAddress,
     startToken: options?.pageKey,
-    withMetadata
+    withMetadata,
+    limit: options?.limit ?? undefined
   });
 
   return {
@@ -435,6 +436,7 @@ interface GetNftsForNftContractAlchemyParams {
   contractAddress: string;
   startToken?: string;
   withMetadata: boolean;
+  limit?: number;
 }
 
 /**

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -152,7 +152,7 @@ export async function getNftsForContract(
     contractAddress,
     startToken: options?.pageKey,
     withMetadata,
-    limit: options?.limit ?? undefined
+    limit: options?.pageSize ?? undefined
   });
 
   return {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -513,7 +513,7 @@ export interface GetNftsForContractOptions {
   omitMetadata?: boolean;
 
   /** Sets the total number of NFTs to return in the response. Defaults to 100. */
-  limit?: number;
+  pageSize?: number;
 }
 
 /**
@@ -536,7 +536,7 @@ export interface GetBaseNftsForContractOptions {
   omitMetadata: false;
 
   /** Sets the total number of NFTs to return in the response. Defaults to 100. */
-  limit?: number;
+  pageSize?: number;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -424,7 +424,7 @@ export interface GetFloorPriceResponse {
   readonly looksRare: FloorPriceMarketplace | FloorPriceError;
 }
 
-/** The refresh result response object returned by {@link refreshNftContract}. */
+/** The refresh result response object returned by {@link refreshContract}. */
 export interface RefreshContractResult {
   /** The NFT contract address that was passed in to be refreshed. */
   contractAddress: string;
@@ -495,7 +495,7 @@ export interface RawContract {
 
 /**
  * Optional parameters object for the {@link getNftsForContract} and
- * {@link getNftsForNftContractIterator} functions.
+ * {@link getNftsForContractIterator} functions.
  *
  * This interface is used to fetch NFTs with their associated metadata. To get
  * Nfts without their associated metadata, use {@link GetBaseNftsForContractOptions}.
@@ -511,11 +511,14 @@ export interface GetNftsForContractOptions {
 
   /** Optional boolean flag to omit NFT metadata. Defaults to `false`. */
   omitMetadata?: boolean;
+
+  /** Sets the total number of NFTs to return in the response. Defaults to 100. */
+  limit?: number;
 }
 
 /**
  * Optional parameters object for the {@link getNftsForContract} and
- * {@link getNftsForNftContractIterator} functions.
+ * {@link getNftsForContractIterator} functions.
  *
  * This interface is used to fetch NFTs without their associated metadata. To
  * get Nfts with their associated metadata, use {@link GetNftsForContractOptions}.
@@ -531,6 +534,9 @@ export interface GetBaseNftsForContractOptions {
 
   /** Optional boolean flag to omit NFT metadata. Defaults to `false`. */
   omitMetadata: false;
+
+  /** Sets the total number of NFTs to return in the response. Defaults to 100. */
+  limit?: number;
 }
 
 /**

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -151,6 +151,14 @@ describe('E2E integration tests', () => {
     );
   });
 
+  it('getNftsForContract with limit', async () => {
+    const nftsForNftContract = await alchemy.nft.getNftsForContract(
+      contractAddress,
+      { limit: 10 }
+    );
+    expect(nftsForNftContract.nfts.length).toEqual(10);
+  });
+
   it('getIterator', async () => {
     jest.setTimeout(15000);
     console.log('lets paginate');

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -154,7 +154,7 @@ describe('E2E integration tests', () => {
   it('getNftsForContract with limit', async () => {
     const nftsForNftContract = await alchemy.nft.getNftsForContract(
       contractAddress,
-      { limit: 10 }
+      { pageSize: 10 }
     );
     expect(nftsForNftContract.nfts.length).toEqual(10);
   });

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -578,7 +578,7 @@ describe('NFT module', () => {
         await alchemy.nft.getNftsForContract(contractAddress, {
           pageKey,
           omitMetadata,
-          limit: 90
+          pageSize: 90
         });
         expect(mock.history.get.length).toEqual(1);
         expect(mock.history.get[0].params).toHaveProperty(

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -537,7 +537,7 @@ describe('NFT module', () => {
     });
   });
 
-  describe('getNftsForNftContract()', () => {
+  describe('getNftsForContract()', () => {
     const contractAddress = '0xCA1';
     const pageKey = 'page-key0';
     const baseResponse: RawGetBaseNftsForContractResponse = {
@@ -577,7 +577,8 @@ describe('NFT module', () => {
         mock.onGet().reply(200, mockResponse);
         await alchemy.nft.getNftsForContract(contractAddress, {
           pageKey,
-          omitMetadata
+          omitMetadata,
+          limit: 90
         });
         expect(mock.history.get.length).toEqual(1);
         expect(mock.history.get[0].params).toHaveProperty(
@@ -592,6 +593,7 @@ describe('NFT module', () => {
           'withMetadata',
           expectedWithMetadata
         );
+        expect(mock.history.get[0].params).toHaveProperty('limit', 90);
       }
     );
 


### PR DESCRIPTION
Updating to match the public [changelog entry](https://docs.alchemy.com/changelog/06182022).

Renaming the field to `pageSize` in order to better standardize with `pageKey`.