### PR TITLE
Add support for ARB_GOERLI 

### DIFF
--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -4,7 +4,8 @@ import {
 } from '@ethersproject/providers';
 import {
   Network as NetworkFromEthers,
-  Networkish
+  Networkish,
+  getNetwork as getNetworkFromEthers
 } from '@ethersproject/networks';
 import { ConnectionInfo, fetchJson } from '@ethersproject/web';
 import { deepCopy } from '@ethersproject/properties';
@@ -84,6 +85,28 @@ export class AlchemyProvider
       );
     }
     return apiKey;
+  }
+
+  /**
+   * Overrides the `BaseProvider.getNetwork` method as implemented by ethers.js.
+   *
+   * This override allows the SDK to set the provider's network to values not
+   * yet supported by ethers.js.
+   *
+   * @internal
+   * @override
+   */
+  static getNetwork(network: Networkish): NetworkFromEthers {
+    // TODO: Remove this override when ethers.js supports ARB_GOERLI.
+    if (network === EthersNetwork[Network.ARB_GOERLI]) {
+      return {
+        chainId: 421613,
+        name: 'arbitrum-goerli'
+      };
+    }
+
+    // Call the standard ethers.js getNetwork method for other networks.
+    return getNetworkFromEthers(network);
   }
 
   /**

--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -4,7 +4,8 @@ import { AlchemyProvider } from './alchemy-provider';
 import { Listener } from '@ethersproject/abstract-provider';
 import {
   AlchemyEventType,
-  AlchemyPendingTransactionsEventFilter
+  AlchemyPendingTransactionsEventFilter,
+  Network
 } from '../types/types';
 import {
   BatchPart,
@@ -36,6 +37,11 @@ import {
   WebSocketProvider
 } from '@ethersproject/providers';
 import { AlchemyConfig } from './alchemy-config';
+import {
+  getNetwork as getNetworkFromEthers,
+  Networkish
+} from '@ethersproject/networks';
+import { Network as NetworkFromEthers } from '@ethersproject/networks/lib/types';
 
 const HEARTBEAT_INTERVAL = 30000;
 const HEARTBEAT_WAIT_TIME = 10000;
@@ -118,6 +124,28 @@ export class AlchemyWebSocketProvider
     this.addSocketListeners();
     this.startHeartbeat();
     this.cancelBackfill = noop;
+  }
+
+  /**
+   * Overrides the `BaseProvider.getNetwork` method as implemented by ethers.js.
+   *
+   * This override allows the SDK to set the provider's network to values not
+   * yet supported by ethers.js.
+   *
+   * @internal
+   * @override
+   */
+  static getNetwork(network: Networkish): NetworkFromEthers {
+    // TODO: Remove this override when ethers.js supports ARB_GOERLI.
+    if (network === EthersNetwork[Network.ARB_GOERLI]) {
+      return {
+        chainId: 421613,
+        name: 'arbitrum-goerli'
+      };
+    }
+
+    // Call the standard ethers.js getNetwork method for other networks.
+    return getNetworkFromEthers(network);
   }
 
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -53,6 +53,7 @@ export enum Network {
   OPT_GOERLI = 'opt-goerli',
   ARB_MAINNET = 'arb-mainnet',
   ARB_RINKEBY = 'arb-rinkeby',
+  ARB_GOERLI = 'arb-goerli',
   MATIC_MAINNET = 'polygon-mainnet',
   MATIC_MUMBAI = 'polygon-mumbai'
 }

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -43,6 +43,7 @@ export const EthersNetwork = {
   [Network.OPT_GOERLI]: 'optimism-goerli',
   [Network.ARB_MAINNET]: 'arbitrum',
   [Network.ARB_RINKEBY]: 'arbitrum-rinkeby',
+  [Network.ARB_GOERLI]: 'arbitrum-goerli',
   [Network.MATIC_MAINNET]: 'matic',
   [Network.MATIC_MUMBAI]: 'maticmum'
 };

--- a/test/unit/alchemy.test.ts
+++ b/test/unit/alchemy.test.ts
@@ -16,7 +16,6 @@ describe('Alchemy class', () => {
         await alchemy.config.getProvider();
       });
     }
-
     for (const network of Object.values(Network)) {
       testNetwork(network);
     }

--- a/test/unit/provider.test.ts
+++ b/test/unit/provider.test.ts
@@ -1,6 +1,20 @@
-import { Alchemy } from '../../src';
+import { Alchemy, Network } from '../../src';
 
 describe('AlchemyProvider', () => {
+  describe('translates Network to ethers', () => {
+    function testNetwork(network: Network) {
+      it(`should return a valid provider for ${network}`, async () => {
+        const alchemy = new Alchemy({
+          network
+        });
+        await alchemy.config.getWebSocketProvider();
+      });
+    }
+    for (const network of Object.values(Network)) {
+      testNetwork(network);
+    }
+  });
+
   it('accepts a URL hard override', async () => {
     const alchemy = new Alchemy({
       apiKey: 'demo-key',


### PR DESCRIPTION
This PR adds support for the Arbitrum-Goerli Network.

Since the underlying ethers.js provider doesn't have support for this network yet, this PR adds the override to the `static getNetwork()` function that ethers uses to verify the network. Any subsequent network overrides can just be added into the `getNetwork()` calls on both the regular and websocket providers.

Also added some unit and integration tests to verify the e2e behavior of each network for all the providers.
