### PR TITLE
Add contract metadata into NFT responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 ## Unreleased
 
 ## Major Changes
+
 - POTENTIALLY BREAKING: Fixed a typing bug where the `totalSupply` field in an `NftContract` should have type `string` instead of `number`.
+- Updated the `Nft` class to include the contract metadata in the `Nft.contract` field.
 
 ## 2.0.4
 
 ### Minor Changes
+
 - Added a `size` field to the `Media` object in the NFT metadata responses to indicate the size of the media in bytes.
-- Bumped `@ethersproject` dependencies to `v5.7.0` to support `safe` and `finalized` blocks.  
+- Bumped `@ethersproject` dependencies to `v5.7.0` to support `safe` and `finalized` blocks.
 
 ## 2.0.3
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The SDK leverages Alchemy's hardened node infrastructure, guaranteeing best-in-c
 
 > 🙋‍♀️ **FEATURE REQUESTS:** We'd love your thoughts on what would improve your web3 dev process the most! If you have 5 minutes, tell us what you want at our [Feature Request feedback form](https://alchemyapi.typeform.com/sdk-feedback), and we'd love to build it for you:
 
-The SDK currently supports the following chains: 
+The SDK currently supports the following chains:
+
 - **Ethereum**: Mainnet, Goerli
 - **Polygon**: Mainnet, Mumbai
 - **Optimism**: Mainnet, Goerli, Kovan
 - **Arbitrum**: Mainnet, Goerli, Rinkeby
 - **Astar**: Mainnet
-
 
 ## Getting started
 

--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -6,6 +6,7 @@ import { Media, NftMetadata, NftTokenType, TokenUri } from '../types/types';
  * @public
  */
 export interface BaseNftContract {
+  /** The address of the contract. */
   address: string;
 }
 
@@ -44,6 +45,9 @@ export interface BaseNft {
  * @public
  */
 export interface Nft extends BaseNft {
+  /** The NFT's underlying contract and relevant contract metadata. */
+  contract: NftContract;
+
   /** The NFT title. */
   title: string;
 

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -28,6 +28,7 @@ export interface RawNft extends RawBaseNft {
   metadata?: NftMetadata;
   timeLastUpdated: string;
   error?: string;
+  contractMetadata?: RawNftContractMetadata;
 }
 
 /**
@@ -52,11 +53,18 @@ export interface RawNftContract {
   contractMetadata: RawNftContractMetadata;
 }
 
-interface RawNftContractMetadata {
+/**
+ * Represents the contract address and metadata of an NFT object received from
+ * Alchemy. This field is separated out since not all NFT API endpoints return a
+ * contract field.
+ *
+ * @internal
+ */
+export interface RawNftContractMetadata {
   name?: string;
   symbol?: string;
   totalSupply?: string;
-  tokenType: NftTokenType;
+  tokenType?: NftTokenType;
 }
 
 /**

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -48,10 +48,17 @@ export function getBaseNftFromRaw(
 }
 
 export function getNftFromRaw(rawNft: RawNft, contractAddress: string): Nft {
+  const tokenType = parseNftTokenType(rawNft.id.tokenMetadata?.tokenType);
   return {
-    contract: { address: contractAddress },
+    contract: {
+      address: contractAddress,
+      name: rawNft.contractMetadata?.name,
+      symbol: rawNft.contractMetadata?.symbol,
+      totalSupply: rawNft.contractMetadata?.totalSupply,
+      tokenType
+    },
     tokenId: parseNftTokenId(rawNft.id.tokenId),
-    tokenType: parseNftTokenType(rawNft.id.tokenMetadata?.tokenType),
+    tokenType,
     title: rawNft.title,
     description: parseNftDescription(rawNft.description),
     timeLastUpdated: rawNft.timeLastUpdated,

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -125,6 +125,17 @@ describe('E2E integration tests', () => {
     expect(withSpam.totalCount).not.toEqual(noSpam.totalCount);
   });
 
+  it('getNftsForOwner() contract metadata check', async () => {
+    const nfts = await alchemy.nft.getNftsForOwner('0xshah.eth');
+    expect(
+      nfts.ownedNfts.filter(
+        nft =>
+          nft.contract.symbol !== undefined &&
+          nft.contract.totalSupply !== undefined
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
   it('getOwnersForNftContract', async () => {
     const response = await alchemy.nft.getOwnersForContract(contractAddress);
     expect(response.owners.length).toBeGreaterThan(0);
@@ -147,6 +158,20 @@ describe('E2E integration tests', () => {
       { pageSize: 10 }
     );
     expect(nftsForNftContract.nfts.length).toEqual(10);
+  });
+
+  it('getNftsForContract() contract metadata check', async () => {
+    const response = await alchemy.nft.getNftsForContract(
+      '0x246e29ef6987637e48e7509f91521ce64eb8c831',
+      { omitMetadata: false }
+    );
+    expect(
+      response.nfts.filter(
+        nft =>
+          nft.contract.symbol !== undefined &&
+          nft.contract.totalSupply !== undefined
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it('getIterator', async () => {
@@ -287,6 +312,7 @@ describe('E2E integration tests', () => {
           expect(block).toBeDefined();
         });
       }
+
       for (const network of Object.values(Network)) {
         testNetwork(network);
       }
@@ -306,6 +332,7 @@ describe('E2E integration tests', () => {
           return done.promise;
         });
       }
+
       for (const network of Object.values(Network)) {
         testNetwork(network);
       }

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -5,7 +5,8 @@ import {
   RawNft,
   RawNftContract,
   RawOwnedBaseNft,
-  RawOwnedNft
+  RawOwnedNft,
+  RawNftContractMetadata
 } from '../src/internal/raw-interfaces';
 import {
   BaseNft,
@@ -25,6 +26,7 @@ import {
 } from '../src/util/util';
 import { BaseNftContract } from '../src/api/nft';
 
+/** Creates a dummy response for the `getContractMetadata` endpoint. */
 export function createRawNftContract(
   address: string,
   tokenType: NftTokenType,
@@ -113,32 +115,38 @@ export function createNft(
   media?: TokenUri[] | undefined
 ): Nft {
   return getNftFromRaw(
-    createRawNft(title, tokenId, tokenType, tokenUri, media),
+    createRawNft(title, tokenId, tokenType, { tokenUri, media }),
     address
   );
+}
+
+interface RawNftOptions {
+  tokenUri?: TokenUri;
+  media?: TokenUri[] | undefined;
+  timeLastUpdated?: string;
+  description?: string | Array<string>;
+  contractMetadata?: RawNftContractMetadata;
 }
 
 export function createRawNft(
   title: string,
   tokenId: string,
   tokenType = NftTokenType.UNKNOWN,
-  tokenUri?: TokenUri,
-  media?: TokenUri[] | undefined,
-  timeLastUpdated?: string,
-  description?: string | Array<string>
+  options?: RawNftOptions
 ): RawNft {
   return {
     title,
-    description: description ?? `a truly unique NFT: ${title}`,
-    timeLastUpdated: timeLastUpdated ?? '2022-02-16T17:12:00.280Z',
+    description: options?.description ?? `a truly unique NFT: ${title}`,
+    timeLastUpdated: options?.timeLastUpdated ?? '2022-02-16T17:12:00.280Z',
     id: {
       tokenId,
       tokenMetadata: {
         tokenType
       }
     },
-    tokenUri,
-    media
+    tokenUri: options?.tokenUri,
+    media: options?.media,
+    contractMetadata: options?.contractMetadata
   };
 }
 
@@ -147,7 +155,8 @@ export function createRawOwnedNft(
   address: string,
   tokenId: string,
   balance: string,
-  tokenType = NftTokenType.UNKNOWN
+  tokenType = NftTokenType.UNKNOWN,
+  contractMetadata?: RawNftContractMetadata
 ): RawOwnedNft {
   return {
     ...createRawNft(title, tokenId, tokenType),
@@ -160,6 +169,7 @@ export function createRawOwnedNft(
         tokenType
       }
     },
+    contractMetadata,
     balance
   };
 }

--- a/test/unit/nft.test.ts
+++ b/test/unit/nft.test.ts
@@ -107,15 +107,11 @@ describe('Nft class', () => {
   it('constructor merges descriptions when it is an array', () => {
     const description = ['very', 'special', 'and unique', 'description'];
 
-    const rawNft = createRawNft(
-      'title',
-      tokenIdString,
-      NftTokenType.ERC721,
-      { raw: '', gateway: '' },
-      [],
-      '2022-02-16T17:12:00.280Z',
+    const rawNft = createRawNft('title', tokenIdString, NftTokenType.ERC721, {
+      tokenUri: { raw: '', gateway: '' },
+      timeLastUpdated: '2022-02-16T17:12:00.280Z',
       description
-    );
+    });
     const nft = getNftFromRaw(rawNft, '0xCA1');
     expect(nft.description).toEqual('very special and unique description');
   });


### PR DESCRIPTION
Fixes #104.

This PR adds contract metadata information into the top-level `Nft.contract` field, unlike the REST API, which has the information in a separate `contractMetadata` field. Added some unit/integration tests + some light refactoring of some test util methods.