### PR TITLE
Validate websocket method name for alchemy subscriptions

### DIFF
--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -25,6 +25,7 @@ import { fromHex } from './util';
 import SturdyWebSocket from 'sturdy-websocket';
 import { VERSION } from '../version';
 import {
+  ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD,
   ALCHEMY_PENDING_TRANSACTIONS_EVENT_TYPE,
   EthersEvent,
   JsonRpcRequest,
@@ -254,6 +255,7 @@ export class AlchemyWebSocketProvider
     once: boolean
   ): this {
     if (isAlchemyEvent(eventName)) {
+      verifyAlchemyEventName(eventName);
       const event = new EthersEvent(
         getAlchemyEventTag(eventName),
         listener,
@@ -780,7 +782,10 @@ export class AlchemyWebSocketProvider
       const { fromAddress, toAddress, hashesOnly } = event;
       void this._subscribe(
         event.tag,
-        ['alchemy_pendingTransactions', { fromAddress, toAddress, hashesOnly }],
+        [
+          ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD,
+          { fromAddress, toAddress, hashesOnly }
+        ],
         this.emitProcessFn(event),
         event
       );
@@ -809,7 +814,7 @@ export class AlchemyWebSocketProvider
         return result =>
           this.emit(
             {
-              method: 'alchemy_pendingTransactions',
+              method: ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD,
               fromAddress,
               toAddress,
               hashesOnly
@@ -1151,5 +1156,15 @@ function serializeBooleanField(field: boolean | undefined): string | undefined {
     return '*';
   } else {
     return field.toString();
+  }
+}
+
+function verifyAlchemyEventName(
+  eventName: AlchemyPendingTransactionsEventFilter
+): void {
+  if (eventName.method !== ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD) {
+    throw new Error(
+      `Invalid method name ${eventName.method}. Accepted method names: ${ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD}`
+    );
   }
 }

--- a/src/internal/internal-types.ts
+++ b/src/internal/internal-types.ts
@@ -16,6 +16,10 @@ type JsonRpcId = string | number | null;
 export const ALCHEMY_PENDING_TRANSACTIONS_EVENT_TYPE =
   'alchemy-pending-transactions';
 
+/** Method name for Alchemy pending transaction subscriptions when using Websockets. */
+export const ALCHEMY_PENDING_TRANSACTIONS_EVENT_METHOD =
+  'alchemy_pendingTransactions';
+
 export interface JsonRpcRequest {
   jsonrpc: '2.0';
   method: string;

--- a/test/unit/websocket-provider.test.ts
+++ b/test/unit/websocket-provider.test.ts
@@ -587,6 +587,21 @@ describe('AlchemyWebSocketProvider', () => {
         ALCHEMY_PENDING_TRANSACTIONS_EVENT_TYPE + ':*:*:*'
       );
     });
+
+    it('throws error for non-recognized method fields', async () => {
+      setupMockServer();
+      initializeWebSocketProvider();
+      const contractAddress = '0x65d25E3F2696B73b850daA07Dd1E267dCfa67F2D';
+      expect(() =>
+        wsProvider.on(
+          {
+            method: 'alchemy_invalidMethod',
+            toAddress: contractAddress
+          },
+          noop
+        )
+      ).toThrow('Invalid method name');
+    });
   });
 
   describe('methods', () => {


### PR DESCRIPTION
Fixes #106.

This PR adds a check to make the method name is in subscriptions is passed in correctly.

We have TS types to guard against people passing in invalid method names, into `alchemy.ws.on()`. Since the current SDK logic defaults to using `alchemy_pendingTransactions` as long as the `method` field is present, JS users can get confusing behavior when trying to use the old websocket subscriptions. 