### PR TITLE
Add common ethers utility methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Major Changes
 - POTENTIALLY BREAKING: Fixed a typing bug where the `totalSupply` field in an `NftContract` should have type `string` instead of `number`.
+- Added commonly used utility methods from ethers.js into a top-level `Utils` export.  
 
 ## 2.0.4
 

--- a/package.json
+++ b/package.json
@@ -60,12 +60,14 @@
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@ethersproject/web": "^5.7.0",
+    "@ethersproject/bytes": "^5.7.0",
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/units": "^5.7.0",
     "axios": "^0.26.1",
     "sturdy-websocket": "^0.2.1",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
-    "@ethersproject/units": "^5.7.0",
     "@microsoft/api-documenter": "^7.16.0",
     "@microsoft/api-extractor": "^7.19.5",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,27 +3,37 @@ import typescriptPlugin from 'rollup-plugin-typescript2';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-const allBuilds = {
-  input: 'src/index.ts',
-  output: [
-    {
-      dir: 'dist/cjs',
-      format: 'cjs',
-      sourcemap: true
-    },
-    {
-      dir: 'dist/esm',
-      format: 'esm',
-      sourcemap: true
-    },
-    {
-      dir: 'dist/es',
-      format: 'es',
-      sourcemap: true
-    }
-  ],
-  external: [...Object.keys(pkg.dependencies || {})],
-  plugins: [typescriptPlugin(), nodeResolve(), commonjs()]
-};
+const isExternalModule = (() => {
+  const deps = new Set(Object.keys(pkg.dependencies));
+  return id => (id.startsWith('.') && id.endsWith('/utils')) || deps.has(id);
+})();
 
-export default allBuilds;
+function makeConfig(input, output) {
+  return {
+    input,
+    output: [
+      {
+        dir: `dist/cjs/${output}`,
+        format: 'cjs',
+        sourcemap: true
+      },
+      {
+        dir: `dist/esm/${output}`,
+        format: 'esm',
+        sourcemap: true
+      },
+      {
+        dir: `dist/es/${output}`,
+        format: 'es',
+        sourcemap: true
+      }
+    ],
+    external: isExternalModule,
+    plugins: [typescriptPlugin(), nodeResolve(), commonjs()]
+  };
+}
+
+export default [
+  makeConfig('src/index.ts', ''),
+  makeConfig('src/api/utils.ts', 'api/')
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,37 +3,46 @@ import typescriptPlugin from 'rollup-plugin-typescript2';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
+const TRUE_ROOT = 'index';
+const roots = [TRUE_ROOT, 'api/utils'];
+const formats = ['cjs', 'esm', 'es'];
+const plugins = [typescriptPlugin(), nodeResolve(), commonjs()];
+
+// e.g. dirFromPath("foo/bar/baz") -> "foo/bar"
+function dirFromPath(path) {
+  const index = path.lastIndexOf('/');
+  return index === -1 ? '' : path.slice(0, index);
+}
+
+// e.g. lastPartOfPath("foo/bar/baz") -> "baz"
+function lastPartOfPath(path) {
+  const index = path.lastIndexOf('/');
+  return path.slice(index + 1);
+}
+
+// Returns true for any dependency listed in package.json and for any member of
+// roots other than index.js, where roots is the array defined above.
 const isExternalModule = (() => {
-  const deps = new Set(Object.keys(pkg.dependencies));
-  return id => (id.startsWith('.') && id.endsWith('/utils')) || deps.has(id);
+  const deps = new Set(Object.keys(pkg.dependencies ?? {}));
+  const subrootEndings = new Set(
+    roots.filter(root => root !== TRUE_ROOT).map(lastPartOfPath)
+  );
+  return id =>
+    deps.has(id) ||
+    (id.startsWith('.') && subrootEndings.has(lastPartOfPath(id)));
 })();
 
-function makeConfig(input, output) {
+function makeConfig(root) {
   return {
-    input,
-    output: [
-      {
-        dir: `dist/cjs/${output}`,
-        format: 'cjs',
-        sourcemap: true
-      },
-      {
-        dir: `dist/esm/${output}`,
-        format: 'esm',
-        sourcemap: true
-      },
-      {
-        dir: `dist/es/${output}`,
-        format: 'es',
-        sourcemap: true
-      }
-    ],
+    input: `src/${root}.ts`,
+    output: formats.map(format => ({
+      dir: `dist/${format}/${dirFromPath(root)}`,
+      format,
+      sourcemap: true
+    })),
     external: isExternalModule,
-    plugins: [typescriptPlugin(), nodeResolve(), commonjs()]
+    plugins
   };
 }
 
-export default [
-  makeConfig('src/index.ts', ''),
-  makeConfig('src/api/utils.ts', 'api/')
-];
+export default roots.map(makeConfig);

--- a/src/api/exported-utils.ts
+++ b/src/api/exported-utils.ts
@@ -1,4 +1,0 @@
-'use strict';
-import * as Utils from './utils';
-
-export { Utils };

--- a/src/api/exported-utils.ts
+++ b/src/api/exported-utils.ts
@@ -1,0 +1,4 @@
+'use strict';
+import * as Utils from './utils';
+
+export { Utils };

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -1,7 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
 
-// TODO: Remove ethers package dependency for smaller bundle size.
-
 /**
  * Converts a hex string to a decimal number.
  *

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,4 +1,4 @@
-export {
+import {
   dnsEncode,
   hashMessage,
   id,
@@ -6,7 +6,7 @@ export {
   namehash
 } from '@ethersproject/hash';
 
-export {
+import {
   arrayify,
   concat,
   hexConcat,
@@ -25,9 +25,32 @@ export {
   stripZeros
 } from '@ethersproject/bytes';
 
-export {
+import {
   formatEther,
   parseEther,
   parseUnits,
   formatUnits
 } from '@ethersproject/units';
+
+export { dnsEncode, hashMessage, id, isValidName, namehash };
+
+export {
+  arrayify,
+  concat,
+  hexConcat,
+  hexDataSlice,
+  hexDataLength,
+  hexlify,
+  hexStripZeros,
+  hexValue,
+  hexZeroPad,
+  isBytes,
+  isBytesLike,
+  isHexString,
+  joinSignature,
+  zeroPad,
+  splitSignature,
+  stripZeros
+};
+
+export { formatEther, parseEther, parseUnits, formatUnits };

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,5 +1,5 @@
 'use strict';
-import {
+export {
   dnsEncode,
   hashMessage,
   id,
@@ -7,7 +7,7 @@ import {
   namehash
 } from '@ethersproject/hash';
 
-import {
+export {
   arrayify,
   concat,
   hexConcat,
@@ -26,37 +26,9 @@ import {
   stripZeros
 } from '@ethersproject/bytes';
 
-import {
+export {
   formatEther,
   parseEther,
   parseUnits,
   formatUnits
 } from '@ethersproject/units';
-
-export {
-  dnsEncode,
-  hashMessage,
-  id,
-  isValidName,
-  namehash,
-  arrayify,
-  concat,
-  hexConcat,
-  hexDataSlice,
-  hexDataLength,
-  hexlify,
-  hexStripZeros,
-  hexValue,
-  hexZeroPad,
-  isBytes,
-  isBytesLike,
-  isHexString,
-  joinSignature,
-  zeroPad,
-  splitSignature,
-  stripZeros,
-  formatEther,
-  parseEther,
-  parseUnits,
-  formatUnits
-};

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,3 +1,4 @@
+'use strict';
 import {
   dnsEncode,
   hashMessage,
@@ -32,9 +33,12 @@ import {
   formatUnits
 } from '@ethersproject/units';
 
-export { dnsEncode, hashMessage, id, isValidName, namehash };
-
 export {
+  dnsEncode,
+  hashMessage,
+  id,
+  isValidName,
+  namehash,
   arrayify,
   concat,
   hexConcat,
@@ -50,7 +54,9 @@ export {
   joinSignature,
   zeroPad,
   splitSignature,
-  stripZeros
+  stripZeros,
+  formatEther,
+  parseEther,
+  parseUnits,
+  formatUnits
 };
-
-export { formatEther, parseEther, parseUnits, formatUnits };

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,0 +1,33 @@
+export {
+  dnsEncode,
+  hashMessage,
+  id,
+  isValidName,
+  namehash
+} from '@ethersproject/hash';
+
+export {
+  arrayify,
+  concat,
+  hexConcat,
+  hexDataSlice,
+  hexDataLength,
+  hexlify,
+  hexStripZeros,
+  hexValue,
+  hexZeroPad,
+  isBytes,
+  isBytesLike,
+  isHexString,
+  joinSignature,
+  zeroPad,
+  splitSignature,
+  stripZeros
+} from '@ethersproject/bytes';
+
+export {
+  formatEther,
+  parseEther,
+  parseUnits,
+  formatUnits
+} from '@ethersproject/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,37 +37,3 @@ export type { BaseNftContract, NftContract, Nft, BaseNft } from './api/nft';
 export { fromHex, toHex, isHex } from './api/util';
 
 export { setLogLevel, LogLevelString as LogLevel } from './util/logger';
-
-export {
-  dnsEncode,
-  hashMessage,
-  id,
-  isValidName,
-  namehash
-} from '@ethersproject/hash';
-
-export {
-  arrayify,
-  concat,
-  hexConcat,
-  hexDataSlice,
-  hexDataLength,
-  hexlify,
-  hexStripZeros,
-  hexValue,
-  hexZeroPad,
-  isBytes,
-  isBytesLike,
-  isHexString,
-  joinSignature,
-  zeroPad,
-  splitSignature,
-  stripZeros
-} from '@ethersproject/bytes';
-
-export {
-  formatEther,
-  parseEther,
-  parseUnits,
-  formatUnits
-} from '@ethersproject/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+'use strict';
 /** This is the main entry point for the library and exports user-facing API. */
 export * from './types/types';
 
@@ -5,7 +6,7 @@ export { Alchemy } from './api/alchemy';
 
 export { Wallet } from './api/alchemy-wallet';
 
-export * as Utils from './api/utils';
+// export { Utils } from './api/exported-utils';
 
 export type { AlchemyConfig } from './api/alchemy-config';
 
@@ -27,36 +28,36 @@ export { fromHex, toHex, isHex } from './api/util';
 
 export { setLogLevel, LogLevelString as LogLevel } from './util/logger';
 
-// export {
-//   dnsEncode,
-//   hashMessage,
-//   id,
-//   isValidName,
-//   namehash
-// } from '@ethersproject/hash';
-//
-// export {
-//   arrayify,
-//   concat,
-//   hexConcat,
-//   hexDataSlice,
-//   hexDataLength,
-//   hexlify,
-//   hexStripZeros,
-//   hexValue,
-//   hexZeroPad,
-//   isBytes,
-//   isBytesLike,
-//   isHexString,
-//   joinSignature,
-//   zeroPad,
-//   splitSignature,
-//   stripZeros
-// } from '@ethersproject/bytes';
-//
-// export {
-//   formatEther,
-//   parseEther,
-//   parseUnits,
-//   formatUnits
-// } from '@ethersproject/units';
+export {
+  dnsEncode,
+  hashMessage,
+  id,
+  isValidName,
+  namehash
+} from '@ethersproject/hash';
+
+export {
+  arrayify,
+  concat,
+  hexConcat,
+  hexDataSlice,
+  hexDataLength,
+  hexlify,
+  hexStripZeros,
+  hexValue,
+  hexZeroPad,
+  isBytes,
+  isBytesLike,
+  isHexString,
+  joinSignature,
+  zeroPad,
+  splitSignature,
+  stripZeros
+} from '@ethersproject/bytes';
+
+export {
+  formatEther,
+  parseEther,
+  parseUnits,
+  formatUnits
+} from '@ethersproject/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export { Alchemy } from './api/alchemy';
 
 export { Wallet } from './api/alchemy-wallet';
 
+export * as Utils from './api/utils';
+
 export type { AlchemyConfig } from './api/alchemy-config';
 
 export type { AlchemyProvider } from './api/alchemy-provider';
@@ -24,3 +26,37 @@ export type { BaseNftContract, NftContract, Nft, BaseNft } from './api/nft';
 export { fromHex, toHex, isHex } from './api/util';
 
 export { setLogLevel, LogLevelString as LogLevel } from './util/logger';
+
+// export {
+//   dnsEncode,
+//   hashMessage,
+//   id,
+//   isValidName,
+//   namehash
+// } from '@ethersproject/hash';
+//
+// export {
+//   arrayify,
+//   concat,
+//   hexConcat,
+//   hexDataSlice,
+//   hexDataLength,
+//   hexlify,
+//   hexStripZeros,
+//   hexValue,
+//   hexZeroPad,
+//   isBytes,
+//   isBytesLike,
+//   isHexString,
+//   joinSignature,
+//   zeroPad,
+//   splitSignature,
+//   stripZeros
+// } from '@ethersproject/bytes';
+//
+// export {
+//   formatEther,
+//   parseEther,
+//   parseUnits,
+//   formatUnits
+// } from '@ethersproject/units';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,22 @@
 'use strict';
 /** This is the main entry point for the library and exports user-facing API. */
+
+// IMPORTANT: when adding namespace imports (imports of the form
+// `import * as X from "./y"`), be sure to also update rollup.config.js so they
+// will be treeshaken correctly.
+
+// Namespace imports here:
+
+import * as Utils from './api/utils';
+export { Utils };
+
+// End namespace imports
+
 export * from './types/types';
 
 export { Alchemy } from './api/alchemy';
 
 export { Wallet } from './api/alchemy-wallet';
-
-import * as Utils from './api/utils';
-export { Utils };
 
 export type { AlchemyConfig } from './api/alchemy-config';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@ export { Alchemy } from './api/alchemy';
 
 export { Wallet } from './api/alchemy-wallet';
 
-// export { Utils } from './api/exported-utils';
+import * as Utils from './api/utils';
+export { Utils };
 
 export type { AlchemyConfig } from './api/alchemy-config';
 


### PR DESCRIPTION
This PR adds commonly used ethers.js utility methods into the top-level export. Huge shoutout to @dphilipson for wrangling rollup to enable treeshaking for this export.

Cleaned up a bit from the original branch: removed extra exports and merged `main.` Verified treeshaking works for different imports in the test webpack project + still works in node and react environments.