### PR TITLE
Add support for 'erc20' in getTokenBalances()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - POTENTIALLY BREAKING: Fixed a typing bug where the `totalSupply` field in an `NftContract` should have type `string` instead of `number`.
 
+### Minor Changes
+
+- Added support for the `erc20` token type and pagination for `CoreNamespace.getTokenBalances()`.
+
 ## 2.0.4
 
 ### Minor Changes

--- a/src/api/core-namespace.ts
+++ b/src/api/core-namespace.ts
@@ -20,12 +20,16 @@ import {
   AssetTransfersWithMetadataParams,
   AssetTransfersWithMetadataResponse,
   DeployResult,
+  TokenBalancesOptionsDefaultTokens,
+  TokenBalancesOptionsErc20,
   TokenBalancesResponse,
+  TokenBalancesResponseErc20,
+  TokenBalanceType,
   TokenMetadataResponse,
   TransactionReceiptsParams,
   TransactionReceiptsResponse
 } from '../types/types';
-import { DEFAULT_CONTRACT_ADDRESSES, ETH_NULL_VALUE } from '../util/const';
+import { ETH_NULL_VALUE } from '../util/const';
 import { toHex } from './util';
 import { formatBlock } from '../util/util';
 
@@ -386,28 +390,98 @@ export class CoreNamespace {
   }
 
   /**
+   * Returns the ERC-20 token balances for a specific owner address.
+   *
+   * @param address The owner address to get the token balances for.
+   * @public
+   */
+  async getTokenBalances(address: string): Promise<TokenBalancesResponseErc20>;
+
+  /**
    * Returns the token balances for a specific owner address given a list of contracts.
    *
    * @param address The owner address to get the token balances for.
    * @param contractAddresses A list of contract addresses to check. If omitted,
-   *   the top 100 tokens by 24 hour volume will be checked.
+   *   all ERC-20 tokens will be checked.
    * @public
    */
   async getTokenBalances(
     address: string,
     contractAddresses?: string[]
-  ): Promise<TokenBalancesResponse> {
-    if (contractAddresses && contractAddresses.length > 1500) {
-      throw new Error(
-        'You cannot pass in more than 1500 contract addresses to getTokenBalances()'
+  ): Promise<TokenBalancesResponse>;
+
+  /**
+   * Returns the ERC-20 token balances for a specific owner.
+   *
+   * This overload covers the erc-20 token type which includes a page key in the response.
+   *
+   * @param address The owner address to get the token balances for.
+   * @param options Token type options set to ERC-20 with optional page key.
+   * @public
+   */
+  async getTokenBalances(
+    address: string,
+    options: TokenBalancesOptionsErc20
+  ): Promise<TokenBalancesResponseErc20>;
+
+  /**
+   * Returns the token balances for a specific owner, fetching from the top 100
+   * tokens by 24 hour volume.
+   *
+   * This overload covers the default token type which includes a page key in
+   * the response.
+   *
+   * @param address The owner address to get the token balances for.
+   * @param options Token type options set to ERC-20 with optional page key.
+   * @public
+   */
+  async getTokenBalances(
+    address: string,
+    options: TokenBalancesOptionsDefaultTokens
+  ): Promise<TokenBalancesResponse>;
+  async getTokenBalances(
+    address: string,
+    contractAddressesOrOptions?:
+      | string[]
+      | TokenBalancesOptionsDefaultTokens
+      | TokenBalancesOptionsErc20
+  ) {
+    const provider = await this.config.getProvider();
+    if (Array.isArray(contractAddressesOrOptions)) {
+      if (contractAddressesOrOptions.length > 1500) {
+        throw new Error(
+          'You cannot pass in more than 1500 contract addresses to getTokenBalances()'
+        );
+      }
+      if (contractAddressesOrOptions.length === 0) {
+        throw new Error(
+          'getTokenBalances() requires at least one contractAddress when using an array'
+        );
+      }
+      return provider._send(
+        'alchemy_getTokenBalances',
+        [address, contractAddressesOrOptions],
+        'getTokenBalances'
+      );
+    } else {
+      const tokenType =
+        contractAddressesOrOptions === undefined
+          ? TokenBalanceType.ERC20
+          : contractAddressesOrOptions.type;
+      const params: Array<string | { pageKey: string }> = [address, tokenType];
+      if (
+        contractAddressesOrOptions?.type === TokenBalanceType.ERC20 &&
+        contractAddressesOrOptions.pageKey
+      ) {
+        console.log(9);
+        params.push({ pageKey: contractAddressesOrOptions.pageKey });
+      }
+      return provider._send(
+        'alchemy_getTokenBalances',
+        params,
+        'getTokenBalances'
       );
     }
-    const provider = await this.config.getProvider();
-    return provider._send(
-      'alchemy_getTokenBalances',
-      [address, contractAddresses || DEFAULT_CONTRACT_ADDRESSES],
-      'getTokenBalances'
-    );
   }
 
   /**

--- a/src/api/core-namespace.ts
+++ b/src/api/core-namespace.ts
@@ -473,7 +473,6 @@ export class CoreNamespace {
         contractAddressesOrOptions?.type === TokenBalanceType.ERC20 &&
         contractAddressesOrOptions.pageKey
       ) {
-        console.log(9);
         params.push({ pageKey: contractAddressesOrOptions.pageKey });
       }
       return provider._send(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -59,6 +59,55 @@ export enum Network {
   ASTAR_MAINNET = 'astar-mainnet'
 }
 
+/** Token Types for the `getTokenBalances()` endpoint. */
+export enum TokenBalanceType {
+  /**
+   * Option to fetch the top 100 tokens by 24-hour volume. This option is only
+   * available on Mainnet in Ethereum, Polygon, and Arbitrum.
+   */
+  DEFAULT_TOKENS = 'DEFAULT_TOKENS',
+
+  /**
+   * Option to fetch the set of ERC-20 tokens that the address as ever held. his
+   * list is produced by an address's historical transfer activity and includes
+   * all tokens that the address has ever received.
+   */
+  ERC20 = 'erc20'
+}
+
+/**
+ * Optional params to pass into `getTokenBalances()` to fetch all ERC-20 tokens
+ * instead of passing in an array of contract addresses to fetch balances for.
+ */
+export interface TokenBalancesOptionsErc20 {
+  /** The ERC-20 token type. */
+  type: TokenBalanceType.ERC20;
+
+  /** Optional page key for pagination (only applicable to TokenBalanceType.ERC20) */
+  pageKey?: string;
+}
+
+/**
+ * Optional params to pass into `getTokenBalances()` to fetch the top 100 tokens
+ * instead of passing in an array of contract addresses to fetch balances for.
+ */
+export interface TokenBalancesOptionsDefaultTokens {
+  /** The top 100 token type. */
+  type: TokenBalanceType.DEFAULT_TOKENS;
+}
+
+/**
+ * Response object for when the {@link TokenBalancesOptionsErc20} options are
+ * used. A page key may be returned if the provided address has many transfers.
+ */
+export interface TokenBalancesResponseErc20 extends TokenBalancesResponse {
+  /**
+   * An optional page key to passed into the next request to fetch the next page
+   * of token balances.
+   */
+  pageKey?: string;
+}
+
 /** @public */
 export interface TokenBalancesResponse {
   address: string;
@@ -866,8 +915,7 @@ export interface DeployResult {
  * @public
  */
 export type AlchemyPendingTransactionsEventFilter = {
-  method: 'alchemy_pendingTransactions';
-  /** Filter pending transactions sent FROM the provided address or array of addresses. */
+  method: 'alchemy_pendingTransactions' /** Filter pending transactions sent FROM the provided address or array of addresses. */;
   fromAddress?: string | string[];
 
   /** Filter pending transactions sent TO the provided address or array of addresses. */

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,7 +1,6 @@
 import { Network } from '../types/types';
 import { Network as NetworkFromEthers } from '@ethersproject/networks';
 
-export const DEFAULT_CONTRACT_ADDRESSES = 'DEFAULT_TOKENS';
 export const DEFAULT_ALCHEMY_API_KEY = 'demo';
 export const DEFAULT_NETWORK = Network.ETH_MAINNET;
 export const DEFAULT_MAX_RETRIES = 5;

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -85,11 +85,12 @@ describe('E2E integration tests', () => {
       type: TokenBalanceType.ERC20
     });
     expect(response.pageKey).toBeDefined();
-    response = await alchemy.core.getTokenBalances(address, {
+    const response2 = await alchemy.core.getTokenBalances(address, {
       type: TokenBalanceType.ERC20,
       pageKey: response.pageKey
     });
-    expect(response.tokenBalances.length).toBeGreaterThan(0);
+    expect(response2.tokenBalances.length).toBeGreaterThan(0);
+    expect(response.tokenBalances[0]).not.toEqual(response2.tokenBalances[0]);
 
     response = await alchemy.core.getTokenBalances(address, [contract]);
     expect(response.tokenBalances.length).toEqual(1);

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -3,7 +3,8 @@ import {
   AssetTransfersCategory,
   Network,
   NftExcludeFilters,
-  NftTokenType
+  NftTokenType,
+  TokenBalanceType
 } from '../../src';
 import { Deferred } from '../test-util';
 
@@ -74,6 +75,24 @@ describe('E2E integration tests', () => {
     expect(firstTransfer.metadata.blockTimestamp).toEqual(
       '2021-04-22T23:13:40.000Z'
     );
+  });
+
+  it('getTokenBalances()', async () => {
+    // Supports ERC-20 + pageKey
+    const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+    const contract = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+    let response = await alchemy.core.getTokenBalances(address, {
+      type: TokenBalanceType.ERC20
+    });
+    expect(response.pageKey).toBeDefined();
+    response = await alchemy.core.getTokenBalances(address, {
+      type: TokenBalanceType.ERC20,
+      pageKey: response.pageKey
+    });
+    expect(response.tokenBalances.length).toBeGreaterThan(0);
+
+    response = await alchemy.core.getTokenBalances(address, [contract]);
+    expect(response.tokenBalances.length).toEqual(1);
   });
 
   it('getNftMetadata', async () => {

--- a/test/unit/core-namespace.test.ts
+++ b/test/unit/core-namespace.test.ts
@@ -1,0 +1,16 @@
+import { Alchemy } from '../../src';
+
+describe('Core Namespace', () => {
+  let alchemy: Alchemy;
+  beforeEach(() => {
+    alchemy = new Alchemy();
+  });
+  describe('getTokenBalances()', () => {
+    it('validates inputs', async () => {
+      const address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+      await expect(() =>
+        alchemy.core.getTokenBalances(address, [])
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for the 'erc20' as an option in `getTokenBalances()` along with corresponding overloads to reflect the optional `pageKey` response and param exclusive to the `erc20` option. This also changes the documentation + default overloads to reflect the endpoint returning `erc20` tokens by default when no 2nd parameter is specified.

Holding off on merging until @dzou confirms that erc20 tokens are returned by default.

Would love feedback on the overloads and if there's any way to simplify some of the logic.