### PR TITLE
Handle bad input in parseNftDescription

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -92,6 +92,11 @@ function parseNftDescription(description?: string | string[]): string {
   if (description === undefined) {
     return '';
   }
+  
+  if (typeof description === "object") {
+    return JSON.stringify(description);
+  }
+  
   return typeof description === 'string' ? description : description.join(' ');
 }
 


### PR DESCRIPTION
Refer to https://github.com/alchemyplatform/alchemy-sdk-js/issues/118

If an NFT with a malformed description property (`object`, when a `string` or `array` is expected) gets sent to an address, it will prevent fetching of all NFTs for that address.

We can fix it by returning an empty string, stringifying the object, or setting description to an error message.