### PR TITLE
Move wallet tests to integration

### DIFF
--- a/test/integration/wallet.test.ts
+++ b/test/integration/wallet.test.ts
@@ -1,0 +1,71 @@
+import { Network, Alchemy, Wallet } from '../../src';
+import { Wallet as EthersWallet } from '@ethersproject/wallet';
+import { TEST_WALLET_PRIVATE_KEY } from '../test-util';
+
+describe('Alchemy-Ethers Wallet', () => {
+  let alchemy: Alchemy;
+
+  beforeAll(async () => {
+    const settings = {
+      network: Network.ETH_MAINNET
+    };
+    alchemy = new Alchemy(settings);
+  });
+
+  it('Matches functionality of Ethers Signer', async () => {
+    const alchProvider = await alchemy.config.getProvider();
+
+    const alchWallet = new Wallet(TEST_WALLET_PRIVATE_KEY, alchemy);
+    const ethersWallet = new EthersWallet(
+      TEST_WALLET_PRIVATE_KEY,
+      alchProvider
+    );
+    const blockTag = 15000000;
+
+    expect(await alchWallet.getBalance(blockTag)).toEqual(
+      await ethersWallet.getBalance(blockTag)
+    );
+    expect(await alchWallet.getTransactionCount(blockTag)).toEqual(
+      await ethersWallet.getTransactionCount(blockTag)
+    );
+    expect(await alchWallet.getChainId()).toEqual(
+      await ethersWallet.getChainId()
+    );
+    expect(await alchWallet.getGasPrice()).toEqual(
+      await ethersWallet.getGasPrice()
+    );
+    expect(await alchWallet.getFeeData()).toEqual(
+      await ethersWallet.getFeeData()
+    );
+    expect(await alchWallet.resolveName('ricmoo.eth')).toEqual(
+      await ethersWallet.resolveName('ricmoo.eth')
+    );
+  });
+
+  it('Works with Alchemy object and Provider object', async () => {
+    const alchProvider = await alchemy.config.getProvider();
+
+    const alchWallet = new Wallet(TEST_WALLET_PRIVATE_KEY, alchemy);
+    const providerWallet = new Wallet(TEST_WALLET_PRIVATE_KEY, alchProvider);
+    const blockTag = 15000000;
+
+    expect(await alchWallet.getBalance(blockTag)).toEqual(
+      await providerWallet.getBalance(blockTag)
+    );
+    expect(await alchWallet.getTransactionCount(blockTag)).toEqual(
+      await providerWallet.getTransactionCount(blockTag)
+    );
+    expect(await alchWallet.getChainId()).toEqual(
+      await providerWallet.getChainId()
+    );
+    expect(await alchWallet.getGasPrice()).toEqual(
+      await providerWallet.getGasPrice()
+    );
+    expect(await alchWallet.getFeeData()).toEqual(
+      await providerWallet.getFeeData()
+    );
+    expect(await alchWallet.resolveName('ricmoo.eth')).toEqual(
+      await providerWallet.resolveName('ricmoo.eth')
+    );
+  });
+});

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -26,6 +26,11 @@ import {
 } from '../src/util/util';
 import { BaseNftContract } from '../src/api/nft';
 
+export const TEST_WALLET_PRIVATE_KEY =
+  'dd5bdf09397b1fdf98e4f72c66047d5104b1511fa7dc1b8fdddd61a150f732c9';
+export const TEST_WALLET_PUBLIC_ADDRESS =
+  '0x4b9007B0BcE78cfB634032ec31Ed56adB464287b';
+
 /** Creates a dummy response for the `getContractMetadata` endpoint. */
 export function createRawNftContract(
   address: string,

--- a/test/unit/wallet.test.ts
+++ b/test/unit/wallet.test.ts
@@ -1,10 +1,9 @@
 import { Network, Alchemy, Wallet } from '../../src';
 import { parseEther, parseUnits } from '@ethersproject/units';
-import { Wallet as EthersWallet } from '@ethersproject/wallet';
-
-const privateKey =
-  'dd5bdf09397b1fdf98e4f72c66047d5104b1511fa7dc1b8fdddd61a150f732c9';
-const publicAddress = '0x4b9007B0BcE78cfB634032ec31Ed56adB464287b';
+import {
+  TEST_WALLET_PRIVATE_KEY,
+  TEST_WALLET_PUBLIC_ADDRESS
+} from '../test-util';
 
 describe('Alchemy-Ethers Wallet', () => {
   let alchemy: Alchemy;
@@ -17,18 +16,18 @@ describe('Alchemy-Ethers Wallet', () => {
   });
 
   it('returns a public address', async () => {
-    const wallet = new Wallet(privateKey);
+    const wallet = new Wallet(TEST_WALLET_PRIVATE_KEY);
     const address = await wallet.getAddress();
-    expect(address).toEqual(publicAddress);
+    expect(address).toEqual(TEST_WALLET_PUBLIC_ADDRESS);
   });
 
   it('connects to an Alchemy Provider', async () => {
-    const wallet = new Wallet(privateKey);
+    const wallet = new Wallet(TEST_WALLET_PRIVATE_KEY);
     const address = await wallet.getAddress();
     const provider = await alchemy.config.getProvider();
 
     const connectedWallet = wallet.connect(await alchemy.config.getProvider());
-    expect(address).toEqual(publicAddress);
+    expect(address).toEqual(TEST_WALLET_PUBLIC_ADDRESS);
     expect(connectedWallet.provider).toEqual(provider);
   });
 
@@ -46,62 +45,8 @@ describe('Alchemy-Ethers Wallet', () => {
       chainId: 5
     };
 
-    const wallet = new Wallet(privateKey);
+    const wallet = new Wallet(TEST_WALLET_PRIVATE_KEY);
     const rawTx = await wallet.signTransaction(transaction);
     expect(rawTx).toEqual(expectedRawTx);
-  });
-
-  it('Matches functionality of Ethers Signer', async () => {
-    const alchProvider = await alchemy.config.getProvider();
-
-    const alchWallet = new Wallet(privateKey, alchemy);
-    const ethersWallet = new EthersWallet(privateKey, alchProvider);
-    const blockTag = 15000000;
-
-    expect(await alchWallet.getBalance(blockTag)).toEqual(
-      await ethersWallet.getBalance(blockTag)
-    );
-    expect(await alchWallet.getTransactionCount(blockTag)).toEqual(
-      await ethersWallet.getTransactionCount(blockTag)
-    );
-    expect(await alchWallet.getChainId()).toEqual(
-      await ethersWallet.getChainId()
-    );
-    expect(await alchWallet.getGasPrice()).toEqual(
-      await ethersWallet.getGasPrice()
-    );
-    expect(await alchWallet.getFeeData()).toEqual(
-      await ethersWallet.getFeeData()
-    );
-    expect(await alchWallet.resolveName('ricmoo.eth')).toEqual(
-      await ethersWallet.resolveName('ricmoo.eth')
-    );
-  });
-
-  it('Works with Alchemy object and Provider object', async () => {
-    const alchProvider = await alchemy.config.getProvider();
-
-    const alchWallet = new Wallet(privateKey, alchemy);
-    const providerWallet = new Wallet(privateKey, alchProvider);
-    const blockTag = 15000000;
-
-    expect(await alchWallet.getBalance(blockTag)).toEqual(
-      await providerWallet.getBalance(blockTag)
-    );
-    expect(await alchWallet.getTransactionCount(blockTag)).toEqual(
-      await providerWallet.getTransactionCount(blockTag)
-    );
-    expect(await alchWallet.getChainId()).toEqual(
-      await providerWallet.getChainId()
-    );
-    expect(await alchWallet.getGasPrice()).toEqual(
-      await providerWallet.getGasPrice()
-    );
-    expect(await alchWallet.getFeeData()).toEqual(
-      await providerWallet.getFeeData()
-    );
-    expect(await alchWallet.resolveName('ricmoo.eth')).toEqual(
-      await providerWallet.resolveName('ricmoo.eth')
-    );
   });
 });


### PR DESCRIPTION
Moving some e2e wallet tests to `integration` for faster test runs.