### PR TITLE
Parse description fields if it's an object

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -92,6 +92,12 @@ function parseNftDescription(description?: string | string[]): string {
   if (description === undefined) {
     return '';
   }
+
+  // TODO: Remove after backend adds JSON stringification.
+  if (!Array.isArray(description) && typeof description === 'object') {
+    return JSON.stringify(description);
+  }
+
   return typeof description === 'string' ? description : description.join(' ');
 }
 


### PR DESCRIPTION
Fixes #118.

Add temporary stringify logic to NFT descriptions until backend adds a check.