### PR TITLE
Added 'bytes' field to 'Media' object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Minor Changes
 
 - Added support for the `erc20` token type and pagination for `CoreNamespace.getTokenBalances()`.
+- Added `bytes` field to the `Media` object in the NFT metadata responses to indicate the size of the media in bytes. Note that the `size` field is not supported by the backend and will be removed in the next version.  
 
 ## 2.0.4
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -457,8 +457,16 @@ export interface Media {
    */
   format?: string;
 
-  /** The size of the media asset in bytes. */
+  /**
+   * DEPRECATED - The size of the media asset in bytes
+   *
+   * @deprecated - Please use {@link bytes} instead. This field will be removed
+   *   in a subsequent release.
+   */
   size?: number;
+
+  /** The size of the media asset in bytes. */
+  bytes?: number;
 }
 
 /**


### PR DESCRIPTION
The backend team didn't end up renaming the `bytes` field to `size`. This PR adds the option and marks `size` as deprecated. Shouldn't be too bad of a change since the field is optional and was never defined. 