### PR TITLE
Add verifyNftOwnership()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - POTENTIALLY BREAKING: Fixed a typing bug where the `totalSupply` field in an `NftContract` should have type `string` instead of `number`.
 - Updated the `Nft` class to include the contract metadata in the `Nft.contract` field.
 - Added commonly used utility methods from ethers.js into a top-level `Utils` export.
+- Added the `NftNamespace.verifyNftOwnership()` method to replace the deprecated `checkNftOwnership()` method. 
 
 ### Minor Changes
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ under the `alchemy.nft` namespace:
   automatically).
 - `getOwnersForNft()`: Get all the owners for a given NFT contract address and a particular token ID.
 - `getOwnersForContract()`: Get all the owners for a given NFT contract address.
-- `checkNftOwnership()`: Check that the provided owner address owns one or more of the provided NFT contract addresses.
+- `verifyNftOwnership()`: Check whether the provided owner address owns the provided NFT contract addresses.
 - `isSpamContract()`: Check whether the given NFT contract address is a spam contract as defined by Alchemy (see the [NFT API FAQ](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification))
 - `getSpamContracts()`: Returns a list of all spam contracts marked by Alchemy.
 - `findContractDeployer()`: Find the contract deployer and block number for a given NFT contract address.

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -32,7 +32,8 @@ import {
   getSpamContracts,
   isSpamContract,
   refreshContract,
-  refreshNftMetadata
+  refreshNftMetadata,
+  verifyNftOwnership
 } from '../internal/nft-api';
 
 /**
@@ -254,17 +255,46 @@ export class NftNamespace {
   }
 
   /**
-   * Checks that the provided owner address owns one of more of the provided NFTs.
+   * DEPRECATED - Checks that the provided owner address owns one of more of the
+   * provided NFTs.
    *
+   * @deprecated - Use {@link verifyNftOwnership} instead. This method will be
+   *   removed in a future release.
    * @param owner - The owner address to check.
    * @param contractAddresses - An array of NFT contract addresses to check ownership for.
-   * @beta
    */
   checkNftOwnership(
     owner: string,
     contractAddresses: string[]
   ): Promise<boolean> {
     return checkNftOwnership(this.config, owner, contractAddresses);
+  }
+
+  /**
+   * Checks that the provided owner address owns one of more of the provided
+   * NFT. Returns a boolean indicating whether the owner address owns the provided NFT.
+   *
+   * @param owner - The owner address to check.
+   * @param contractAddress - An NFT contract address to check ownership for.
+   */
+  verifyNftOwnership(owner: string, contractAddress: string): Promise<boolean>;
+
+  /**
+   * Checks which of the provided NFTs the owner address owns. Returns a map of
+   * contract address to a boolean indicating whether the owner address owns the NFT.
+   *
+   * @param owner - The owner address to check.
+   * @param contractAddresses - An array NFT contract address to check ownership for.
+   */
+  verifyNftOwnership(
+    owner: string,
+    contractAddresses: string[]
+  ): Promise<{ [contractAddress: string]: boolean }>;
+  verifyNftOwnership(
+    owner: string,
+    contractAddress: string | string[]
+  ): Promise<boolean | { [contractAddress: string]: boolean }> {
+    return verifyNftOwnership(this.config, owner, contractAddress);
   }
 
   /**


### PR DESCRIPTION
The `checkNftOwnership()` method is non-intuitive since it returns `true` if the provided owner owns any of the provided NFT addresses. This PR adds support for `verifyNftOwnership()`, which returns a single boolean value if only a single contract address is provided, or a mapping of contractAddress to the ownership result boolean if multiple contract addresses are provided. 

`checkNftOwnership()` is now marked as deprecated.