### PR TITLE
Add types in `exports` field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "module": "dist/esm/index.js",
   "exports": {
     "node": {
+      "types": "./dist/src/index.d.ts",
       "require": "./dist/cjs/index.js",
       "import": "./dist/cjs/index.js"
     },


### PR DESCRIPTION
I'm importing Alchemy SDK in Typescript CommonJS files using `NodeNext` moduleResolution.

This means the package is imported following the rules defined in `exports.node` statement.

I'm getting the following error:
```
Could not find a declaration file for module 'alchemy-sdk'. '<redacted>/node_modules/alchemy-sdk/dist/cjs/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/alchemy-sdk` if it exists or add a new declaration (.d.ts) file containing `declare module 'alchemy-sdk';`
```

According to Typescript `exports`/`imports` documentation, types must be specified at the top of the import condition if they live in a different location. https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

This will fix the issue by specifying the location of the types in this context.