### PR TITLE
Deprecate old networks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,12 +4,12 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 ### [REQUIRED] Environment
-  * Browser version: 
-  * Alchemy SDK version: 
+
+- Browser version:
+- Alchemy SDK version:
 
 ### [REQUIRED] Describe the problem
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: 'FR: <My Feature Request>'
 labels: feature request
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added the `AIDROPS` enum to `NftNamespace.getNftsForOwner()`.
 - Added the `spamInfo` field to the response for `getNftsForOwner()` and `getNftsForContract()`.
+- Marked Ropsten, Rinkeby, and Kovan `Network` enums as deprecated. Please switch over to Goerli.
 
 ## 2.1.0
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -44,14 +44,19 @@ export interface AlchemySettings {
  */
 export enum Network {
   ETH_MAINNET = 'eth-mainnet',
+  /** @deprecated - Will be removed in subsequent versions */
   ETH_ROPSTEN = 'eth-ropsten',
   ETH_GOERLI = 'eth-goerli',
+  /** @deprecated - Will be removed in subsequent versions */
   ETH_KOVAN = 'eth-kovan',
+  /** @deprecated - Will be removed in subsequent versions */
   ETH_RINKEBY = 'eth-rinkeby',
   OPT_MAINNET = 'opt-mainnet',
+  /** @deprecated - Will be removed in subsequent versions */
   OPT_KOVAN = 'opt-kovan',
   OPT_GOERLI = 'opt-goerli',
   ARB_MAINNET = 'arb-mainnet',
+  /** @deprecated - Will be removed in subsequent versions */
   ARB_RINKEBY = 'arb-rinkeby',
   ARB_GOERLI = 'arb-goerli',
   MATIC_MAINNET = 'polygon-mainnet',

--- a/test/integration/alchemy.test.ts
+++ b/test/integration/alchemy.test.ts
@@ -4,6 +4,13 @@ import { Deferred } from '../test-util';
 jest.setTimeout(50000);
 describe('E2E integration tests', () => {
   describe('handles networks', () => {
+    // TODO(deprecation): Remove after removing deprecated networks.
+    const deprecated = ['ropsten', 'kovan', 'rinkeby'];
+    // Filter out deprecated networks.
+    const supportedNetworks = Object.values(Network).filter(
+      network => !deprecated.some(key => network.includes(key))
+    );
+
     describe('AlchemyProvider', () => {
       function testNetwork(network: Network) {
         it(`get blockNumber on ${network}`, async () => {
@@ -15,7 +22,7 @@ describe('E2E integration tests', () => {
         });
       }
 
-      for (const network of Object.values(Network)) {
+      for (const network of supportedNetworks) {
         testNetwork(network);
       }
     });
@@ -35,7 +42,12 @@ describe('E2E integration tests', () => {
         });
       }
 
-      for (const network of Object.values(Network)) {
+      for (const network of supportedNetworks) {
+        // TODO: Enable after Astar websockets work.
+        if (network === Network.ASTAR_MAINNET) {
+          continue;
+        }
+
         testNetwork(network);
       }
     });

--- a/test/integration/core.test.ts
+++ b/test/integration/core.test.ts
@@ -77,7 +77,7 @@ describe('E2E integration tests', () => {
   });
 
   it('getTransactionReceipts()', async () => {
-    const blockNumber = await alchemy.core.getBlockNumber();
+    const blockNumber = (await alchemy.core.getBlockNumber()) - 20;
     const response = await alchemy.core.getTransactionReceipts({
       blockNumber: Utils.hexlify(blockNumber)
     });

--- a/test/integration/transact.test.ts
+++ b/test/integration/transact.test.ts
@@ -15,7 +15,8 @@ describe('E2E integration tests', () => {
   it('sendPrivateTransaction()', async () => {
     const transaction = {
       to: '0xa238b6008Bc2FBd9E386A5d4784511980cE504Cd',
-      value: 10000,
+      // Use random number to allow back to back runs.
+      value: Math.floor(Math.random() * 10000),
       nonce: 2,
       type: 2,
       chainId: 5


### PR DESCRIPTION
Deprecating Rinkeby, Ropsten, and Kovan as per the Alchemy global [changelog](https://docs.alchemy.com/changelog/future-deprecation-of-ropsten-kovan-and-rinkeby#:~:text=deprecated-,%5B10%2F05%2F2022%5D%20Deprecation%20of%20Ropsten%2C%20Kovan,and%20Arb%20Rinkeby%20on%20Arbitrum&text=The%20Ropsten%2C%20Kovan%20and%20Rinkeby,will%20return%20HTTP%20410%20errors.).

Also fixed some integration tests to be less flaky.