### PR TITLE
Require only passing in at least one field to update in webhooks

### DIFF
--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -217,23 +217,27 @@ export class NotifyNamespace {
         webhook_id: webhookId,
         is_active: update.isActive
       };
-    } else if ('addFilters' in update) {
+    } else if ('addFilters' in update || 'removeFilters' in update) {
       restApiName = 'update-webhook-nft-filters';
       methodName = 'webhooks:updateWebhookNftFilters';
       method = 'PATCH';
       data = {
         webhook_id: webhookId,
-        nft_filters_to_add: update.addFilters.map(nftFilterToParam),
-        nft_filters_to_remove: update.removeFilters.map(nftFilterToParam)
+        nft_filters_to_add: update.addFilters
+          ? update.addFilters.map(nftFilterToParam)
+          : [],
+        nft_filters_to_remove: update.removeFilters
+          ? update.removeFilters.map(nftFilterToParam)
+          : []
       };
-    } else if ('addAddresses' in update) {
+    } else if ('addAddresses' in update || 'removeAddresses' in update) {
       restApiName = 'update-webhook-addresses';
       methodName = 'webhook:updateWebhookAddresses';
       method = 'PATCH';
       data = {
         webhook_id: webhookId,
-        addresses_to_add: update.addAddresses,
-        addresses_to_remove: update.removeAddresses
+        addresses_to_add: update.addAddresses ?? [],
+        addresses_to_remove: update.removeAddresses ?? []
       };
     } else if ('newAddresses' in update) {
       restApiName = 'update-webhook-addresses';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1336,7 +1336,9 @@ export interface WebhookAddressOverride {
  * {@link NftActivityWebhook}.
  */
 
-export type NftWebhookUpdate = WebhookStatusUpdate | WebhookNftFilterUpdate;
+export type NftWebhookUpdate =
+  | WebhookStatusUpdate
+  | RequireAtLeastOne<WebhookNftFilterUpdate>;
 
 /**
  * Params object when calling {@link NotifyNamespace.updateWebhook} to update a
@@ -1344,5 +1346,14 @@ export type NftWebhookUpdate = WebhookStatusUpdate | WebhookNftFilterUpdate;
  */
 export type AddressWebhookUpdate =
   | WebhookStatusUpdate
-  | WebhookAddressUpdate
+  | RequireAtLeastOne<WebhookAddressUpdate>
   | WebhookAddressOverride;
+
+/**
+ * Requires at least one of the properties to be set. Implementation copied over
+ * from {@link https://learn.microsoft.com/en-us/javascript/api/@azure/keyvault-certificates/requireatleastone?view=azure-node-latest}
+ */
+export type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> &
+    Partial<Pick<T, Exclude<keyof T, K>>>;
+}[keyof T];

--- a/test/integration/notify.test.ts
+++ b/test/integration/notify.test.ts
@@ -27,6 +27,7 @@ describe('E2E integration tests', () => {
       tokenId: '345'
     }
   ];
+
   const webhookUrl = 'https://temp-site.ngrok.io';
 
   let addressWh: AddressActivityWebhook;
@@ -87,13 +88,28 @@ describe('E2E integration tests', () => {
   });
 
   it('getNftFilters()', async () => {
+    const expectedNftFilters = [
+      {
+        contractAddress: '0x88b48f654c30e99bc2e4a1559b4dcf1ad93fa656',
+        tokenId: '234'
+      },
+      {
+        contractAddress: '0x17dc95f9052f86ed576af55b018360f853e19ac2',
+        tokenId: '345'
+      }
+    ];
+
     let response = await alchemy.notify.getNftFilters(nftWh);
     const sortFn = (a: NftFilter, b: NftFilter) =>
       a.tokenId < b.tokenId ? 1 : -1;
-    expect(response.filters.sort(sortFn)).toEqual(nftFilters.sort(sortFn));
+    expect(response.filters.sort(sortFn)).toEqual(
+      expectedNftFilters.sort(sortFn)
+    );
 
     response = await alchemy.notify.getNftFilters(nftWh.id);
-    expect(response.filters.sort(sortFn)).toEqual(nftFilters.sort(sortFn));
+    expect(response.filters.sort(sortFn)).toEqual(
+      expectedNftFilters.sort(sortFn)
+    );
   });
 
   it('getNftFilters() with limit', async () => {
@@ -219,6 +235,14 @@ describe('E2E integration tests', () => {
 
     const response = await alchemy.notify.getNftFilters(nftWh);
     expect(response.filters.length).toEqual(2);
+
+    await alchemy.notify.updateWebhook(nftWh, {
+      removeFilters
+    });
+
+    await alchemy.notify.updateWebhook(nftWh, {
+      addFilters
+    });
   });
 
   it('update NftActivityWebhook status', async () => {
@@ -242,6 +266,14 @@ describe('E2E integration tests', () => {
     expect(response.addresses.length).toEqual(3);
     expect(response.addresses).toContain(addAddress);
     expect(response.addresses).not.toContain(removeAddress);
+
+    await alchemy.notify.updateWebhook(addressWh, {
+      removeAddresses: [removeAddress]
+    });
+
+    await alchemy.notify.updateWebhook(addressWh, {
+      addAddresses: [addAddress]
+    });
   });
 
   it('override AddressActivityWebhook address', async () => {


### PR DESCRIPTION
This PR changes the update params for Nft and Address Activity params to not require both `add` and `remove` fields to be set.
- If the field is not specified, the SDK fills it in with an empty array.
- Added a TS guard to require at least one of the two properties to be set.
- Added some integration tests to make sure it works.