### PR TITLE
NFT Unichain API for getNftsForOwners

### DIFF
--- a/src/api/alchemy-config.ts
+++ b/src/api/alchemy-config.ts
@@ -61,6 +61,33 @@ export class AlchemyConfig {
   }
 
   /**
+   * Returns the settings provided upon construction with defaults.
+   *
+   * @internal
+   */
+  _getSettings(): AlchemySettings {
+    return {
+      apiKey: this.apiKey,
+      network: this.network,
+      maxRetries: this.maxRetries,
+      url: this.url,
+      authToken: this.authToken
+    };
+  }
+
+  /**
+   * Returns a new config object merged with the provided settings.
+   *
+   * @internal
+   */
+  _clone(mergeConfig?: AlchemySettings): AlchemyConfig {
+    return new AlchemyConfig({
+      ...this._getSettings(),
+      ...mergeConfig
+    });
+  }
+
+  /**
    * Returns the URL endpoint to send the HTTP request to. If a custom URL was
    * provided in the config, that URL is returned. Otherwise, the default URL is
    * from the network and API key.

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -20,6 +20,7 @@ import {
   summarizeNftAttributes,
   verifyNftOwnership
 } from '../internal/nft-api';
+import { UnichainPageKeyCache } from '../internal/page-key';
 import {
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
@@ -58,8 +59,12 @@ import { BaseNft, Nft, NftContract } from './nft';
  * via `alchemy.nft`.
  */
 export class NftNamespace {
+  private unichainPageKeyCache: UnichainPageKeyCache;
+
   /** @internal */
-  constructor(private readonly config: AlchemyConfig) {}
+  constructor(private readonly config: AlchemyConfig) {
+    this.unichainPageKeyCache = new UnichainPageKeyCache();
+  }
 
   /**
    * Get the NFT metadata associated with the provided parameters.
@@ -135,7 +140,10 @@ export class NftNamespace {
       | GetNftsForOwnerUnichainOptions
       | GetBaseNftsForOwnerUnichainOptions = {}
   ): Promise<OwnedNftsResponseUnichain | OwnedBaseNftsResponseUnichain> {
-    return getNftsForOwnerUnichain(this.config, owner, networks, options);
+    return getNftsForOwnerUnichain(this.config, owner, networks, {
+      unichainPageKeyCache: this.unichainPageKeyCache,
+      ...options
+    });
   }
 
   /**

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -112,6 +112,7 @@ export class NftNamespace {
    * @param owner - The address of the owner.
    * @param options - The optional parameters to use for the request.
    * @public
+   * @beta
    */
   getNftsForOwnerUnichain(
     owner: string,
@@ -127,6 +128,7 @@ export class NftNamespace {
    * @param owner - The address of the owner.
    * @param options - The optional parameters to use for the request.
    * @public
+   * @beta
    */
   getNftsForOwnerUnichain(
     owner: string,

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -10,6 +10,7 @@ import {
   getNftsForContractIterator,
   getNftsForOwner,
   getNftsForOwnerIterator,
+  getNftsForOwnerUnichain,
   getOwnersForContract,
   getOwnersForNft,
   getSpamContracts,
@@ -22,14 +23,17 @@ import {
 import {
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
+  GetBaseNftsForOwnerUnichainOptions,
   GetFloorPriceResponse,
   GetNftsForContractOptions,
   GetNftsForOwnerOptions,
+  GetNftsForOwnerUnichainOptions,
   GetOwnersForContractOptions,
   GetOwnersForContractResponse,
   GetOwnersForContractWithTokenBalancesOptions,
   GetOwnersForContractWithTokenBalancesResponse,
   GetOwnersForNftResponse,
+  Network,
   NftAttributeRarity,
   NftAttributesResponse,
   NftContractBaseNftsResponse,
@@ -37,8 +41,10 @@ import {
   NftTokenType,
   OwnedBaseNft,
   OwnedBaseNftsResponse,
+  OwnedBaseNftsResponseUnichain,
   OwnedNft,
   OwnedNftsResponse,
+  OwnedNftsResponseUnichain,
   RefreshContractResult
 } from '../types/types';
 import { AlchemyConfig } from './alchemy-config';
@@ -90,6 +96,46 @@ export class NftNamespace {
    */
   getContractMetadata(contractAddress: string): Promise<NftContract> {
     return getContractMetadata(this.config, contractAddress);
+  }
+
+  /**
+   * Get all NFTs for an owner across a given set of networks.
+   *
+   * This method returns the full NFT. To get all NFTs without
+   * their associated metadata, use {@link GetBaseNftsForOwnerUnichainOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerUnichain(
+    owner: string,
+    networks: Network[],
+    options?: GetNftsForOwnerUnichainOptions
+  ): Promise<OwnedNftsResponseUnichain>;
+  /**
+   * Get all base NFTs for an owner across a given set of networks.
+   *
+   * This method returns the base NFTs that omit the associated metadata. To get
+   * all NFTs with their associated metadata, use {@link GetNftsForOwnerUnichainOptions}.
+   *
+   * @param owner - The address of the owner.
+   * @param options - The optional parameters to use for the request.
+   * @public
+   */
+  getNftsForOwnerUnichain(
+    owner: string,
+    networks: Network[],
+    options?: GetBaseNftsForOwnerUnichainOptions
+  ): Promise<OwnedBaseNftsResponseUnichain>;
+  getNftsForOwnerUnichain(
+    owner: string,
+    networks: Network[],
+    options:
+      | GetNftsForOwnerUnichainOptions
+      | GetBaseNftsForOwnerUnichainOptions = {}
+  ): Promise<OwnedNftsResponseUnichain | OwnedBaseNftsResponseUnichain> {
+    return getNftsForOwnerUnichain(this.config, owner, networks, options);
   }
 
   /**

--- a/src/internal/nft-api-unichain.ts
+++ b/src/internal/nft-api-unichain.ts
@@ -12,7 +12,7 @@ import { getNftsForOwner } from './nft-api';
 import { NetworkPageKey, UnichainPageKeyCache } from './page-key';
 
 function networksAreEqual(a: Network[], b: Network[]): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return JSON.stringify(a.sort()) === JSON.stringify(b.sort());
 }
 
 function validateParams(

--- a/src/internal/nft-api-unichain.ts
+++ b/src/internal/nft-api-unichain.ts
@@ -1,0 +1,155 @@
+import { AlchemyConfig } from '../api/alchemy-config';
+import {
+  GetBaseNftsForOwnerUnichainOptions,
+  GetNftsForOwnerUnichainOptions,
+  Network,
+  OwnedBaseNftsResponse,
+  OwnedBaseNftsResponseUnichain,
+  OwnedNftsResponse,
+  OwnedNftsResponseUnichain
+} from '../types/types';
+import { getNftsForOwner } from './nft-api';
+import { NetworkPageKey, UnichainPageKeyCache } from './page-key';
+
+function networksAreEqual(a: Network[], b: Network[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function validateParams(
+  networks: Network[],
+  options:
+    | GetNftsForOwnerUnichainOptions
+    | GetBaseNftsForOwnerUnichainOptions = {}
+): {
+  unichainPageKeyCache: UnichainPageKeyCache;
+  networkPageKeys: Map<Network, NetworkPageKey>;
+} {
+  // We could default to all networks, but as we add or remove support for
+  // various networks that list can change. We force developers to explicitly
+  // list their desired networks so that their code is future-proof.
+  if (!networks || networks.length === 0) {
+    throw new Error(
+      'Must provide a `networks` parameter for unichain requests.'
+    );
+  }
+
+  const { unichainPageKeyCache, pageKey = null } = options;
+
+  // This should be provided by default in the namespace, so realistically
+  // should never happen. In non-unichain methods we do not use a page key
+  // cache because page keys are handled by the API. However we have no API
+  // for unichain, and so the SDK needs to handle page keys.
+  if (!unichainPageKeyCache) {
+    throw new Error('No page key cache was provided.');
+  }
+
+  const networkPageKeys = unichainPageKeyCache.getNetworkPageKeys(pageKey);
+
+  // If the user made an initial request for a set of networks, we do not
+  // allow them to change networks on the next page. We could technically
+  // allow this, but it would require significantly more magic.
+  const originalNetworks = Array.from(networkPageKeys.keys());
+  if (pageKey && !networksAreEqual(originalNetworks, networks)) {
+    throw new Error('Networks must not change between pages.');
+  }
+
+  return {
+    unichainPageKeyCache,
+    networkPageKeys
+  };
+}
+
+function buildResponseWithPageKey(
+  networks: Network[],
+  networkResults: (OwnedNftsResponse | OwnedBaseNftsResponse)[],
+  unichainPageKeyCache: UnichainPageKeyCache
+) {
+  const response: OwnedNftsResponseUnichain = {
+    nftsByNetwork: new Map()
+  };
+  const networkPageKeys = new Map();
+
+  for (let i = 0; i < networks.length; i++) {
+    const network = networks[i];
+    const resultsForNetwork = networkResults[i];
+
+    response.nftsByNetwork.set(network, resultsForNetwork);
+    networkPageKeys.set(network, new NetworkPageKey(resultsForNetwork.pageKey));
+  }
+
+  const unichainPageKey = UnichainPageKeyCache.generateKey(networkPageKeys);
+  if (unichainPageKey) {
+    unichainPageKeyCache.set(unichainPageKey, networkPageKeys);
+    return {
+      ...response,
+      pageKey: unichainPageKey
+    };
+  }
+
+  return response;
+}
+
+export async function getNftsForOwnerUnichain(
+  config: AlchemyConfig,
+  owner: string,
+  networks: Network[],
+  options:
+    | GetNftsForOwnerUnichainOptions
+    | GetBaseNftsForOwnerUnichainOptions = {}
+): Promise<OwnedNftsResponseUnichain | OwnedBaseNftsResponseUnichain> {
+  const {
+    getNftsForOwnerFn = getNftsForOwner,
+    pageKey: _pageKey,
+    unichainPageKeyCache: _unichainPageKeyCache,
+    ...baseOptions
+  } = options;
+
+  const { unichainPageKeyCache, networkPageKeys } = validateParams(
+    networks,
+    options
+  );
+
+  const networkResults = await Promise.all(
+    networks.map(network => {
+      // Copies the default configuration and replaces the network.
+      const networkConfig = config._clone({
+        network
+      });
+
+      const networkPageKey = networkPageKeys.get(network);
+      // In non-unichain requests the developer will interpret a _missing_
+      // page key to mean that there are no more pages. For a unichain
+      // request, however, some networks might have no page key while the
+      // others do. In this case the unichain request still needs to send
+      // back a page key. This page key will point to network-specific keys
+      // that may or may not be empty. So when we run the network-specific
+      // request we first have to check if there _is_ a next page.
+      if (networkPageKey && !networkPageKey.hasNextPage()) {
+        return {
+          // If we have already returned all the NFTs for a network, then
+          // the next page will return an empty set.
+          ownedNfts: [],
+          // Todo: Normally a request for page > 1 would still return the
+          // same totalCount as the first page. Since we are returning an
+          // empty set without calling the API we don't know the real total
+          // count. With some more clever caching we could get it from a
+          // previous page.
+          totalCount: 0
+        };
+      }
+
+      const pageKeyOption = networkPageKey && networkPageKey.value();
+
+      return getNftsForOwnerFn(networkConfig, owner, {
+        ...baseOptions,
+        pageKey: pageKeyOption
+      });
+    })
+  );
+
+  return buildResponseWithPageKey(
+    networks,
+    networkResults,
+    unichainPageKeyCache
+  );
+}

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -63,6 +63,12 @@ export async function getNftsForOwnerUnichain(
     | GetNftsForOwnerUnichainOptions
     | GetBaseNftsForOwnerUnichainOptions = {}
 ): Promise<OwnedNftsResponseUnichain | OwnedBaseNftsResponseUnichain> {
+  if (!networks || networks.length === 0) {
+    throw new Error(
+      'Must provide a `networks` parameter for unichain requests.'
+    );
+  }
+
   const { getNftsForOwnerFn = getNftsForOwner, ...baseOptions } = options;
 
   const networkResults = await Promise.all(

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -5,14 +5,17 @@ import { BaseNft, Nft, NftContract } from '../api/nft';
 import {
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
+  GetBaseNftsForOwnerUnichainOptions,
   GetFloorPriceResponse,
   GetNftsForContractOptions,
   GetNftsForOwnerOptions,
+  GetNftsForOwnerUnichainOptions,
   GetOwnersForContractOptions,
   GetOwnersForContractResponse,
   GetOwnersForContractWithTokenBalancesOptions,
   GetOwnersForContractWithTokenBalancesResponse,
   GetOwnersForNftResponse,
+  Network,
   NftAttributeRarity,
   NftAttributesResponse,
   NftContractBaseNftsResponse,
@@ -20,8 +23,10 @@ import {
   NftTokenType,
   OwnedBaseNft,
   OwnedBaseNftsResponse,
+  OwnedBaseNftsResponseUnichain,
   OwnedNft,
   OwnedNftsResponse,
+  OwnedNftsResponseUnichain,
   RefreshContractResult,
   RefreshState
 } from '../types/types';
@@ -49,6 +54,36 @@ import {
   RawOwnedNft,
   RawReingestContractResponse
 } from './raw-interfaces';
+
+export async function getNftsForOwnerUnichain(
+  config: AlchemyConfig,
+  owner: string,
+  networks: Network[],
+  options:
+    | GetNftsForOwnerUnichainOptions
+    | GetBaseNftsForOwnerUnichainOptions = {}
+): Promise<OwnedNftsResponseUnichain | OwnedBaseNftsResponseUnichain> {
+  const { getNftsForOwnerFn = getNftsForOwner, ...baseOptions } = options;
+
+  const networkResults = await Promise.all(
+    networks.map(network => {
+      const networkConfig = config._clone({
+        network
+      });
+
+      return getNftsForOwnerFn(networkConfig, owner, baseOptions);
+    })
+  );
+
+  const response: OwnedNftsResponseUnichain = {};
+  for (let i = 0; i < networks.length; i++) {
+    const network = networks[i];
+    const results = networkResults[i];
+    response[network] = results;
+  }
+
+  return response;
+}
 
 export async function getNftMetadata(
   config: AlchemyConfig,

--- a/src/internal/page-key.ts
+++ b/src/internal/page-key.ts
@@ -1,8 +1,5 @@
 import { Network } from '../types/types';
 
-const PAGE_KEY_EXPIRATION_MS = 1_000 * 60 * 10;
-const NO_MORE_PAGES_STRING = 'FINISHED';
-
 type NetworkPageKeys = Map<Network, NetworkPageKey>;
 
 interface UnichainPageKeyValue {
@@ -11,10 +8,15 @@ interface UnichainPageKeyValue {
 }
 
 export class NetworkPageKey {
+  // When a network has no next page we will save a page key with this
+  // value. The hasNextPage() method will return false for any page key
+  // matching this value.
+  private NO_MORE_PAGES = 'NO_MORE_PAGES';
+
   private pageKey: string;
 
   constructor(pageKey?: any) {
-    this.pageKey = pageKey ? pageKey.toString() : NO_MORE_PAGES_STRING;
+    this.pageKey = pageKey ? pageKey.toString() : this.NO_MORE_PAGES;
   }
 
   public value(): string {
@@ -22,15 +24,25 @@ export class NetworkPageKey {
   }
 
   public hasNextPage(): boolean {
-    return this.value() !== NO_MORE_PAGES_STRING;
+    return this.value() !== this.NO_MORE_PAGES;
   }
 }
 
+// As of today, the API expires page keys in 15 minutes. We set the
+// unichain expiration to be less than that in order to ensure that
+// we never deal with expired network keys.
+const DEFAULT_UNICHAIN_PAGE_KEY_EXPIRATION_MS = 1_000 * 60 * 10;
+
 export class UnichainPageKeyCache {
+  private pageKeyExpirationMs: number;
   private cache: Record<string, UnichainPageKeyValue>;
 
-  constructor() {
-    this.cache = {};
+  constructor(
+    cache: Record<string, UnichainPageKeyValue> = {},
+    pageKeyExpirationMs: number = DEFAULT_UNICHAIN_PAGE_KEY_EXPIRATION_MS
+  ) {
+    this.cache = cache;
+    this.pageKeyExpirationMs = pageKeyExpirationMs;
   }
 
   public static generateKey(networkPageKeys: NetworkPageKeys): string | null {
@@ -47,7 +59,7 @@ export class UnichainPageKeyCache {
   public set(unichainKey: string, networkPageKeys: NetworkPageKeys): void {
     this.cache[unichainKey] = {
       networkPageKeys,
-      expiresAt: Date.now() + PAGE_KEY_EXPIRATION_MS
+      expiresAt: Date.now() + this.pageKeyExpirationMs
     };
   }
 
@@ -65,8 +77,11 @@ export class UnichainPageKeyCache {
       return new Map();
     }
 
+    // We provde a custom error for an expired unichain page key, because
+    // if we allowed the request to hit the API then the developer would
+    // get back a more cryptic error about page keys from the API.
     if (Date.now() > value.expiresAt) {
-      throw new Error('Page key is expired.');
+      throw new Error('Unichain page key is expired.');
     }
 
     return value.networkPageKeys;

--- a/src/internal/page-key.ts
+++ b/src/internal/page-key.ts
@@ -1,0 +1,74 @@
+import { Network } from '../types/types';
+
+const PAGE_KEY_EXPIRATION_MS = 1_000 * 60 * 10;
+const NO_MORE_PAGES_STRING = 'FINISHED';
+
+type NetworkPageKeys = Map<Network, NetworkPageKey>;
+
+interface UnichainPageKeyValue {
+  networkPageKeys: NetworkPageKeys;
+  expiresAt: number;
+}
+
+export class NetworkPageKey {
+  private pageKey: string;
+
+  constructor(pageKey?: any) {
+    this.pageKey = pageKey ? pageKey.toString() : NO_MORE_PAGES_STRING;
+  }
+
+  public value(): string {
+    return this.pageKey;
+  }
+
+  public hasNextPage(): boolean {
+    return this.value() !== NO_MORE_PAGES_STRING;
+  }
+}
+
+export class UnichainPageKeyCache {
+  private cache: Record<string, UnichainPageKeyValue>;
+
+  constructor() {
+    this.cache = {};
+  }
+
+  public static generateKey(networkPageKeys: NetworkPageKeys): string | null {
+    const anyHasNextPage = Array.from(networkPageKeys.values()).find(key =>
+      key.hasNextPage()
+    );
+    if (!anyHasNextPage) {
+      return null;
+    }
+
+    return `${Date.now()}${Math.round(Math.random() * 100000000)}`;
+  }
+
+  public set(unichainKey: string, networkPageKeys: NetworkPageKeys): void {
+    this.cache[unichainKey] = {
+      networkPageKeys,
+      expiresAt: Date.now() + PAGE_KEY_EXPIRATION_MS
+    };
+  }
+
+  public get(unichainKey: string): UnichainPageKeyValue | null {
+    return this.cache[unichainKey] || null;
+  }
+
+  public getNetworkPageKeys(unichainKey: string | null): NetworkPageKeys {
+    if (!unichainKey) {
+      return new Map();
+    }
+
+    const value = this.get(unichainKey);
+    if (!value) {
+      return new Map();
+    }
+
+    if (Date.now() > value.expiresAt) {
+      throw new Error('Page key is expired.');
+    }
+
+    return value.networkPageKeys;
+  }
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -687,13 +687,13 @@ export interface OwnedBaseNftsResponse {
  * @public
  */
 export interface OwnedNftsResponseUnichain {
-  nftsByNetwork: Map<Network, OwnedNftsResponse>;
+  nftsByNetwork: Map<Network, OwnedNftsResponse | OwnedBaseNftsResponse>;
 
   /** Optional page key that is returned when any network has a next page. */
   pageKey?: string;
 }
 export interface OwnedBaseNftsResponseUnichain {
-  nftsByNetwork: Map<Network, OwnedNftsResponse>;
+  nftsByNetwork: Map<Network, OwnedNftsResponse | OwnedBaseNftsResponse>;
 
   /** Optional page key that is returned when any network has a next page. */
   pageKey?: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,12 +5,9 @@ import {
 import { BigNumberish } from '@ethersproject/bignumber';
 
 import { BaseNft, Nft } from '../api/nft';
+import { UnichainPageKeyCache } from '../internal/page-key';
 
 // TODO: separate this file into other files.
-
-type OptionalRecord<K extends keyof any, T> = {
-  [P in K]?: T;
-};
 
 /**
  * Options object used to configure the Alchemy SDK.
@@ -548,9 +545,20 @@ export interface GetNftsForOwnerOptions {
 
 export interface GetNftsForOwnerUnichainOptions extends GetNftsForOwnerOptions {
   /**
+   * A local cache with a map of unichain pageKey to network pageKeys.
+   */
+  unichainPageKeyCache?: UnichainPageKeyCache;
+
+  /**
    * Function to call to get an owner's nfts for a single network.
    */
   getNftsForOwnerFn?: Function;
+
+  /**
+   * Optional page key from an existing {@link OwnedBaseNftsResponseUnichain} or
+   * {@link OwnedNftsResponseUnichain}to use for pagination.
+   */
+  pageKey?: string;
 }
 
 /**
@@ -599,9 +607,20 @@ export interface GetBaseNftsForOwnerOptions {
 export interface GetBaseNftsForOwnerUnichainOptions
   extends GetBaseNftsForOwnerOptions {
   /**
+   * A local cache with a map of unichain pageKey to network pageKeys.
+   */
+  unichainPageKeyCache?: UnichainPageKeyCache;
+
+  /**
    * Function to call to get an owner's nfts for a single network.
    */
   getNftsForOwnerFn?: Function;
+
+  /**
+   * Optional page key from an existing {@link OwnedBaseNftsResponseUnichain} or
+   * {@link OwnedNftsResponseUnichain}to use for pagination.
+   */
+  pageKey?: string;
 }
 
 /**
@@ -663,18 +682,22 @@ export interface OwnedBaseNftsResponse {
 }
 
 /**
- * The response object for the {@link getNftsForOwnerUnichain} function.
+ * The response objects for the {@link getNftsForOwnerUnichain} function.
  *
  * @public
  */
-export type OwnedNftsResponseUnichain = OptionalRecord<
-  Network,
-  OwnedNftsResponse
->;
-export type OwnedBaseNftsResponseUnichain = OptionalRecord<
-  Network,
-  OwnedBaseNftsResponse
->;
+export interface OwnedNftsResponseUnichain {
+  nftsByNetwork: Map<Network, OwnedNftsResponse>;
+
+  /** Optional page key that is returned when any network has a next page. */
+  pageKey?: string;
+}
+export interface OwnedBaseNftsResponseUnichain {
+  nftsByNetwork: Map<Network, OwnedNftsResponse>;
+
+  /** Optional page key that is returned when any network has a next page. */
+  pageKey?: string;
+}
 
 /**
  * Represents an NFT with metadata owned by an address.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -8,6 +8,10 @@ import { BaseNft, Nft } from '../api/nft';
 
 // TODO: separate this file into other files.
 
+type OptionalRecord<K extends keyof any, T> = {
+  [P in K]?: T;
+};
+
 /**
  * Options object used to configure the Alchemy SDK.
  *
@@ -542,6 +546,13 @@ export interface GetNftsForOwnerOptions {
   tokenUriTimeoutInMs?: number;
 }
 
+export interface GetNftsForOwnerUnichainOptions extends GetNftsForOwnerOptions {
+  /**
+   * Function to call to get an owner's nfts for a single network.
+   */
+  getNftsForOwnerFn?: Function;
+}
+
 /**
  * Optional parameters object for the {@link getNftsForOwner} and
  * {@link getNftsForOwnerIterator} functions.
@@ -583,6 +594,14 @@ export interface GetBaseNftsForOwnerOptions {
    * metadata for cache misses then set this value to 0.
    */
   tokenUriTimeoutInMs?: number;
+}
+
+export interface GetBaseNftsForOwnerUnichainOptions
+  extends GetBaseNftsForOwnerOptions {
+  /**
+   * Function to call to get an owner's nfts for a single network.
+   */
+  getNftsForOwnerFn?: Function;
 }
 
 /**
@@ -642,6 +661,20 @@ export interface OwnedBaseNftsResponse {
   /** The total count of NFTs owned by the provided address. */
   readonly totalCount: number;
 }
+
+/**
+ * The response object for the {@link getNftsForOwnerUnichain} function.
+ *
+ * @public
+ */
+export type OwnedNftsResponseUnichain = OptionalRecord<
+  Network,
+  OwnedNftsResponse
+>;
+export type OwnedBaseNftsResponseUnichain = OptionalRecord<
+  Network,
+  OwnedBaseNftsResponse
+>;
 
 /**
  * Represents an NFT with metadata owned by an address.

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -575,6 +575,8 @@ describe('NFT module', () => {
       );
     });
 
+    it.todo('returns no page key when all network pages are done');
+
     describe('for a network that has no next page', () => {
       it.todo('preserves the totalCount');
     });

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -357,7 +357,7 @@ describe('NFT module', () => {
     });
   });
 
-  describe.only('getNftsForOwnerUnichain()', () => {
+  describe('getNftsForOwnerUnichain()', () => {
     it('calls getNftsForOwner with each provided network', async () => {
       const getNftsForOwner = jest
         .fn()
@@ -533,6 +533,7 @@ describe('NFT module', () => {
         'some_unichain_cache_key',
         new Map([
           [Network.ETH_MAINNET, new NetworkPageKey('an_eth_mainnet_page_key')],
+          [Network.MATIC_MAINNET, new NetworkPageKey()],
           [Network.OPT_MAINNET, new NetworkPageKey('an_opt_mainnet_page_key')]
         ])
       );
@@ -556,14 +557,12 @@ describe('NFT module', () => {
           pageKey: 'an_eth_mainnet_page_key'
         })
       );
-      expect(getNftsForOwner).toHaveBeenCalledWith(
+      expect(getNftsForOwner).not.toHaveBeenCalledWith(
         expect.objectContaining({
           network: Network.MATIC_MAINNET
         }),
         expect.anything(),
-        expect.objectContaining({
-          pageKey: undefined
-        })
+        expect.anything()
       );
       expect(getNftsForOwner).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
## Motivation

Some developers have expressed that it is annoying to call NFT API endpoints for each network that they are interested in. Some end-users may want to view their NFTs across all networks at once, for instance. This PR attempts to address this feedback for the `getNftsForOwner` method.

## Request Ergonomics

In order to keep requests as ergonomic as possible, I decided to add the unichain api to the existing NFT namespace. That means developers will still initialize an `Alchemy` class with an initial network. This feels a little strange, as the developer using the unichain API will still be using a config that has a single network in it. However, it felt preferrable to other options, e.g. creating a new `Network` type called "Unichain".

The unichain API takes one additional parameter to the regular API, which is an array of `networks: Network[]`. The `options` dictionary is still supported and will be passed into each call to `getNftsForOwner`.

## Response Format

At first I considered keeping the response object for the unichain call the same as for `getNftsForOwner`, i.e.

```
export interface OwnedNftsResponse {
  /** The NFTs owned by the provided address. */
  readonly ownedNfts: OwnedNft[];
  /**
   * Pagination token that can be passed into another request to fetch the next
   * NFTs. If there is no page key, then there are no more NFTs to fetch.
   */
  readonly pageKey?: string;
  /** The total count of NFTs owned by the provided address. */
  readonly totalCount: number;
}
```

However, a single list of owned NFTs would not be distinguishable by network. I would have to create a new `OwnedNft` type with a network field.

Another (perhaps larger) reason to create a new response is that pagination and sorting are an open question when it comes to this response format. Since we are making requests to multiple networks we will usually have more than 100 results. How do we decide which 100 to return? How do we sort them? How do we handle pagination? I decided to remove this complexity for now.

## Implementation

The concept behind the unichain API is simple -- the developer provides a set of networks and we call `getNftsForOwner` for each network. The complicated part is managing page keys.

In a single-network API (read: all current APIs), the developer knows they have reached the end of the result set when the API does _not_ return a page key. For a unichain request, however, some networks may be out of pages while others have many more to go. This makes the unichain page key a bit of a sticky wicket. The one behavior I sought to maintain is that if the unichain API does _not_ return a page key that means the developer is done with _all_ pages on _all_ networks.

In any case... happy reviewing!