### PR TITLE
Add uniqueId for AssetTransfersResult

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -333,6 +333,9 @@ export interface AssetTransfersWithMetadataResponse {
  * @public
  */
 export interface AssetTransfersResult {
+  /** The unique ID of the transfer. */
+  uniqueId: string;
+
   /** The category of the transfer. */
   category: AssetTransfersCategory;
 


### PR DESCRIPTION
Just figure out that the `uniqueId` field is missing from the type.