### PR TITLE
Add openSea property to `getContractMetadata()`

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,7 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# CodeStream ignored files
-/codestream.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,7 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# CodeStream ignored files
+/codestream.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added the `NftNamespace.summarizeNftAttributes()` method to get the summary of attribute prevalence for all NFTs in a contract.
 - Added support for ENS resolution on several methods. You should now be able to pass in an ENS domain into any param that requires an owner address. 
 - Added the `CoreNamespace.resolveName()` and `CoreNamespace.lookupAddress()` methods to resolve and lookup ENS domains and their owner addresses.
+- Added the `openSea` response to `NftNamespace.getContractMetadata()` (#162). 
 
 ## 2.2.0
 

--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -2,6 +2,7 @@ import {
   Media,
   NftMetadata,
   NftTokenType,
+  OpenSeaCollectionMetadata,
   SpamInfo,
   TokenUri
 } from '../types/types';
@@ -32,21 +33,6 @@ export interface NftContract extends BaseNftContract {
   totalSupply?: string;
   /** OpenSea's metadata for the contract. */
   openSea?: OpenSeaCollectionMetadata;
-}
-
-/**
- * OpenSea's metadata for an NFT collection.
- */
-export interface OpenSeaCollectionMetadata {
-  floorPrice: number;
-  collectionName: string;
-  safelistRequestStatus?: 'verified';
-  imageUrl: string;
-  description: string;
-  externalUrl: string;
-  twitterUsername: string;
-  discordUrl: string;
-  lastIngestedAt: string;
 }
 
 /**

--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -30,6 +30,23 @@ export interface NftContract extends BaseNftContract {
   symbol?: string;
   /** The number of NFTs in the contract as an integer string. */
   totalSupply?: string;
+  /** OpenSea's metadata for the contract. */
+  openSea?: OpenSeaCollectionMetadata;
+}
+
+/**
+ * OpenSea's metadata for an NFT collection.
+ */
+export interface OpenSeaCollectionMetadata {
+  floorPrice: number;
+  collectionName: string;
+  safelistRequestStatus?: 'verified';
+  imageUrl: string;
+  description: string;
+  externalUrl: string;
+  twitterUsername: string;
+  discordUrl: string;
+  lastIngestedAt: string;
 }
 
 /**

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -86,15 +86,15 @@ export interface RawNftContractMetadata {
  * OpenSea's metadata for an NFT collection.
  */
 export interface RawOpenSeaCollectionMetadata {
-  floorPrice: number;
-  collectionName: string;
-  safelistRequestStatus?: 'verified';
-  imageUrl: string;
-  description: string;
-  externalUrl: string;
-  twitterUsername: string;
-  discordUrl: string;
-  lastIngestedAt: string;
+  floorPrice?: number;
+  collectionName?: string;
+  safelistRequestStatus?: string;
+  imageUrl?: string;
+  description?: string;
+  externalUrl?: string;
+  twitterUsername?: string;
+  discordUrl?: string;
+  lastIngestedAt?: string;
 }
 
 /**

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -79,6 +79,22 @@ export interface RawNftContractMetadata {
   symbol?: string;
   totalSupply?: string;
   tokenType?: NftTokenType;
+  openSea?: RawOpenSeaCollectionMetadata;
+}
+
+/**
+ * OpenSea's metadata for an NFT collection.
+ */
+export interface RawOpenSeaCollectionMetadata {
+  floorPrice: number;
+  collectionName: string;
+  safelistRequestStatus?: 'verified';
+  imageUrl: string;
+  description: string;
+  externalUrl: string;
+  twitterUsername: string;
+  discordUrl: string;
+  lastIngestedAt: string;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1051,6 +1051,42 @@ export interface NftContractNftsResponse {
 }
 
 /**
+ * OpenSea's metadata for an NFT collection.
+ */
+export interface OpenSeaCollectionMetadata {
+  /** The floor price of the NFT. */
+  floorPrice?: number;
+  /** The name of the collection on OpenSea. */
+  collectionName?: string;
+  /** The approval status of the collection on OpenSea. */
+  safelistRequestStatus?: OpenSeaSafelistRequestStatus;
+  /** The image URL determined by OpenSea. */
+  imageUrl?: string;
+  /** The description of the collection on OpenSea. */
+  description?: string;
+  /** The homepage of the collection as determined by OpenSea.*/
+  externalUrl?: string;
+  /** The Twitter handle of the collection. */
+  twitterUsername?: string;
+  /** The Discord URL of the collection. */
+  discordUrl?: string;
+  /** Timestamp of when the OpenSea metadata was last ingested by Alchemy. */
+  lastIngestedAt?: string;
+}
+
+/** An OpenSea collection's approval status. */
+export enum OpenSeaSafelistRequestStatus {
+  /** Verified collection. */
+  VERIFIED = 'verified',
+  /** Collections that are approved on open sea and can be found in search results. */
+  APPROVED = 'approved',
+  /** Collections that requested safelisting on OpenSea. */
+  REQUESTED = 'requested',
+  /** Brand new collections. */
+  NOT_REQUESTED = 'not_requested'
+}
+
+/**
  * The response object for the {@link findContractDeployer} function.
  *
  * @public

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -35,13 +35,29 @@ export function getBaseNftContractFromRaw(
 export function getNftContractFromRaw(
   rawNftContract: RawNftContract
 ): NftContract {
-  return {
+  const contract: NftContract = {
     address: rawNftContract.address,
     name: rawNftContract.contractMetadata.name,
     symbol: rawNftContract.contractMetadata.symbol,
     totalSupply: rawNftContract.contractMetadata.totalSupply,
     tokenType: parseNftTokenType(rawNftContract.contractMetadata.tokenType)
   };
+  if (rawNftContract.contractMetadata.openSea) {
+    contract.openSea = {
+      floorPrice: rawNftContract.contractMetadata.openSea.floorPrice,
+      collectionName: rawNftContract.contractMetadata.openSea.collectionName,
+      safelistRequestStatus:
+        rawNftContract.contractMetadata.openSea.safelistRequestStatus,
+      imageUrl: rawNftContract.contractMetadata.openSea.imageUrl,
+      description: rawNftContract.contractMetadata.openSea.description,
+      externalUrl: rawNftContract.contractMetadata.openSea.externalUrl,
+      twitterUsername: rawNftContract.contractMetadata.openSea.twitterUsername,
+      discordUrl: rawNftContract.contractMetadata.openSea.discordUrl,
+      lastIngestedAt: rawNftContract.contractMetadata.openSea.lastIngestedAt
+    };
+  }
+
+  return contract;
 }
 
 export function getBaseNftFromRaw(

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -13,6 +13,7 @@ import {
 import {
   NftAttributeRarity,
   NftTokenType,
+  OpenSeaSafelistRequestStatus,
   SpamInfo,
   TokenUri
 } from '../types/types';
@@ -24,6 +25,13 @@ export function formatBlock(block: string | number): string {
     return toHex(block);
   }
   return block.toString();
+}
+
+function stringToEnum<T extends string>(
+  x: string,
+  enumb: Record<string, T>
+): T | undefined {
+  return Object.values(enumb).includes(x as T) ? (x as T) : undefined;
 }
 
 export function getBaseNftContractFromRaw(
@@ -43,17 +51,21 @@ export function getNftContractFromRaw(
     tokenType: parseNftTokenType(rawNftContract.contractMetadata.tokenType)
   };
   if (rawNftContract.contractMetadata.openSea) {
+    const safeListStatus =
+      rawNftContract.contractMetadata.openSea?.safelistRequestStatus;
     contract.openSea = {
-      floorPrice: rawNftContract.contractMetadata.openSea.floorPrice,
-      collectionName: rawNftContract.contractMetadata.openSea.collectionName,
+      floorPrice: rawNftContract.contractMetadata.openSea?.floorPrice,
+      collectionName: rawNftContract.contractMetadata.openSea?.collectionName,
       safelistRequestStatus:
-        rawNftContract.contractMetadata.openSea.safelistRequestStatus,
-      imageUrl: rawNftContract.contractMetadata.openSea.imageUrl,
-      description: rawNftContract.contractMetadata.openSea.description,
-      externalUrl: rawNftContract.contractMetadata.openSea.externalUrl,
-      twitterUsername: rawNftContract.contractMetadata.openSea.twitterUsername,
-      discordUrl: rawNftContract.contractMetadata.openSea.discordUrl,
-      lastIngestedAt: rawNftContract.contractMetadata.openSea.lastIngestedAt
+        safeListStatus !== undefined
+          ? stringToEnum(safeListStatus, OpenSeaSafelistRequestStatus)
+          : undefined,
+      imageUrl: rawNftContract.contractMetadata.openSea?.imageUrl,
+      description: rawNftContract.contractMetadata.openSea?.description,
+      externalUrl: rawNftContract.contractMetadata.openSea?.externalUrl,
+      twitterUsername: rawNftContract.contractMetadata.openSea?.twitterUsername,
+      discordUrl: rawNftContract.contractMetadata.openSea?.discordUrl,
+      lastIngestedAt: rawNftContract.contractMetadata.openSea?.lastIngestedAt
     };
   }
 

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -1,4 +1,9 @@
-import { Alchemy, NftExcludeFilters, NftTokenType } from '../../src';
+import {
+  Alchemy,
+  NftExcludeFilters,
+  NftTokenType,
+  OpenSeaSafelistRequestStatus
+} from '../../src';
 
 jest.setTimeout(50000);
 
@@ -34,6 +39,13 @@ describe('E2E integration tests', () => {
     expect(response.tokenType).toEqual(NftTokenType.ERC721);
     expect(response.address).toEqual(contractAddress);
     expect(typeof response.name).toEqual('string');
+    expect(response.openSea).toBeDefined();
+    expect(response.openSea?.safelistRequestStatus).toBeDefined();
+    expect(
+      Object.values(OpenSeaSafelistRequestStatus).includes(
+        response.openSea?.safelistRequestStatus!
+      )
+    ).toEqual(true);
   });
 
   it('getOwnersForNft()', async () => {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -17,6 +17,7 @@ import {
   RawNft,
   RawNftContract,
   RawNftContractMetadata,
+  RawOpenSeaCollectionMetadata,
   RawOwnedBaseNft,
   RawOwnedNft
 } from '../src/internal/raw-interfaces';
@@ -38,7 +39,8 @@ export function createRawNftContract(
   tokenType: NftTokenType,
   name?: string,
   symbol?: string,
-  totalSupply?: string
+  totalSupply?: string,
+  openSea?: RawOpenSeaCollectionMetadata
 ): RawNftContract {
   return {
     address,
@@ -46,7 +48,8 @@ export function createRawNftContract(
       name,
       symbol,
       totalSupply,
-      tokenType
+      tokenType,
+      openSea
     }
   };
 }

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -27,7 +27,8 @@ import {
   RawGetNftsForContractResponse,
   RawGetNftsResponse,
   RawGetOwnersForContractWithTokenBalancesResponse,
-  RawNftAttributeRarity
+  RawNftAttributeRarity,
+  RawOpenSeaCollectionMetadata
 } from '../../src/internal/raw-interfaces';
 import {
   getNftContractFromRaw,
@@ -69,13 +70,27 @@ describe('NFT module', () => {
     const symbol = 'NCN';
     const totalSupply = '9999';
     const tokenType = NftTokenType.ERC721;
+    const openSea: RawOpenSeaCollectionMetadata = {
+      floorPrice: 2.2998,
+      collectionName: 'World of Women',
+      safelistRequestStatus: 'verified',
+      imageUrl:
+        'https://i.seadn.io/gae/EFAQpIktMBU5SU0TqSdPWZ4byHr3hFirL_mATsR8KWhM5z-GJljX8E73V933lkyKgv2SAFlfRRjGsWvWbQQmJAwu3F2FDXVa1C9F?w=500&auto=format',
+      description:
+        'A community celebrating representation, inclusivity, and equal opportunities for all.\r\nUnited by a first-of-its-kind collection, featuring 10,000 artworks of diverse and powerful women.\r\n\r\nCreated and Illustrated by Yam Karkai (@ykarkai)\r\n\r\nNew official collection World of Women Galaxy available here:\r\nhttps://opensea.io/collection/world-of-women-galaxy',
+      externalUrl: 'http://worldofwomen.art',
+      twitterUsername: 'worldofwomennft',
+      discordUrl: 'https://discord.gg/worldofwomen',
+      lastIngestedAt: '2022-10-26T22:24:49.000Z'
+    };
 
     const rawNftContractResponse = createRawNftContract(
       address,
       tokenType,
       name,
       symbol,
-      totalSupply
+      totalSupply,
+      openSea
     );
     const expectedNftContract = getNftContractFromRaw(rawNftContractResponse);
 
@@ -90,7 +105,8 @@ describe('NFT module', () => {
       name: string,
       symbol: string,
       totalSupply: string,
-      tokenType?: NftTokenType
+      tokenType?: NftTokenType,
+      openSea?: RawOpenSeaCollectionMetadata
     ) {
       expect(actualNftContract).toEqual(expectedNftContract);
 
@@ -99,6 +115,33 @@ describe('NFT module', () => {
       expect(actualNftContract.symbol).toEqual(symbol);
       expect(actualNftContract.totalSupply).toEqual(totalSupply);
       expect(actualNftContract.tokenType).toEqual(tokenType);
+      if (openSea) {
+        expect(actualNftContract.openSea?.floorPrice).toEqual(
+          openSea.floorPrice
+        );
+        expect(actualNftContract.openSea?.collectionName).toEqual(
+          openSea.collectionName
+        );
+        expect(actualNftContract.openSea?.safelistRequestStatus).toEqual(
+          openSea.safelistRequestStatus
+        );
+        expect(actualNftContract.openSea?.imageUrl).toEqual(openSea.imageUrl);
+        expect(actualNftContract.openSea?.description).toEqual(
+          openSea.description
+        );
+        expect(actualNftContract.openSea?.externalUrl).toEqual(
+          openSea.externalUrl
+        );
+        expect(actualNftContract.openSea?.twitterUsername).toEqual(
+          openSea.twitterUsername
+        );
+        expect(actualNftContract.openSea?.discordUrl).toEqual(
+          openSea.discordUrl
+        );
+        expect(actualNftContract.openSea?.lastIngestedAt).toEqual(
+          openSea.lastIngestedAt
+        );
+      }
 
       expect(mock.history.get.length).toEqual(1);
       expect(mock.history.get[0].params).toHaveProperty(

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -73,15 +73,13 @@ describe('NFT module', () => {
     const tokenType = NftTokenType.ERC721;
     const openSea: RawOpenSeaCollectionMetadata = {
       floorPrice: 2.2998,
-      collectionName: 'World of Women',
+      collectionName: 'Collection Name',
       safelistRequestStatus: 'verified',
-      imageUrl:
-        'https://i.seadn.io/gae/EFAQpIktMBU5SU0TqSdPWZ4byHr3hFirL_mATsR8KWhM5z-GJljX8E73V933lkyKgv2SAFlfRRjGsWvWbQQmJAwu3F2FDXVa1C9F?w=500&auto=format',
-      description:
-        'A community celebrating representation, inclusivity, and equal opportunities for all.\r\nUnited by a first-of-its-kind collection, featuring 10,000 artworks of diverse and powerful women.\r\n\r\nCreated and Illustrated by Yam Karkai (@ykarkai)\r\n\r\nNew official collection World of Women Galaxy available here:\r\nhttps://opensea.io/collection/world-of-women-galaxy',
-      externalUrl: 'http://worldofwomen.art',
-      twitterUsername: 'worldofwomennft',
-      discordUrl: 'https://discord.gg/worldofwomen',
+      imageUrl: 'http://image.url',
+      description: 'A sample description',
+      externalUrl: 'http://external.url',
+      twitterUsername: 'twitter-handle',
+      discordUrl: 'https://discord.gg/example',
       lastIngestedAt: '2022-10-26T22:24:49.000Z'
     };
 


### PR DESCRIPTION
Fixes #162.

This PR updates the SDK to include the new `openSea` property on the `NftNamespace.getContractMetadata()` endpoint.