### PR TITLE
Use alchemy.env in all integration tests

### DIFF
--- a/test/integration/alchemy.test.ts
+++ b/test/integration/alchemy.test.ts
@@ -1,8 +1,11 @@
 import { Alchemy, Network } from '../../src';
-import { Deferred } from '../test-util';
+import { Deferred, loadAlchemyEnv } from '../test-util';
 
 jest.setTimeout(50000);
 describe('E2E integration tests', () => {
+  beforeAll(async () => {
+    await loadAlchemyEnv();
+  });
   describe('handles networks', () => {
     // TODO(deprecation): Remove after removing deprecated networks.
     const deprecated = ['ropsten', 'kovan', 'rinkeby'];
@@ -15,6 +18,7 @@ describe('E2E integration tests', () => {
       function testNetwork(network: Network) {
         it(`get blockNumber on ${network}`, async () => {
           const alchemy = new Alchemy({
+            apiKey: process.env.ALCHEMY_API_KEY,
             network
           });
           const block = await alchemy.core.getBlockNumber();
@@ -31,6 +35,7 @@ describe('E2E integration tests', () => {
       function testNetwork(network: Network) {
         it(`block subscription for ${network}`, () => {
           const alchemy = new Alchemy({
+            apiKey: process.env.ALCHEMY_API_KEY,
             network
           });
           const done = new Deferred<void>();

--- a/test/integration/core.test.ts
+++ b/test/integration/core.test.ts
@@ -1,5 +1,6 @@
 import { Alchemy, AssetTransfersCategory, TokenBalanceType } from '../../src';
 import { Utils } from '../../src/index';
+import { loadAlchemyEnv } from '../test-util';
 
 jest.setTimeout(50000);
 // Integration tests for Alchemy's custom methods on top the core ethers' offerings.
@@ -7,7 +8,10 @@ describe('E2E integration tests', () => {
   let alchemy: Alchemy;
 
   beforeAll(async () => {
-    alchemy = await new Alchemy();
+    await loadAlchemyEnv();
+    alchemy = await new Alchemy({
+      apiKey: process.env.ALCHEMY_API_KEY
+    });
 
     // Skip all timeouts for testing.
     jest.setTimeout(50000);

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -4,6 +4,7 @@ import {
   NftTokenType,
   OpenSeaSafelistRequestStatus
 } from '../../src';
+import { loadAlchemyEnv } from '../test-util';
 
 jest.setTimeout(50000);
 
@@ -15,7 +16,10 @@ describe('E2E integration tests', () => {
   const contractAddress = '0x01234567bac6ff94d7e4f0ee23119cf848f93245';
 
   beforeAll(async () => {
-    alchemy = await new Alchemy();
+    await loadAlchemyEnv();
+    alchemy = await new Alchemy({
+      apiKey: process.env.ALCHEMY_API_KEY
+    });
 
     // Skip all timeouts for testing.
     jest.setTimeout(50000);

--- a/test/integration/provider.test.ts
+++ b/test/integration/provider.test.ts
@@ -7,6 +7,7 @@ import {
   AlchemyWebSocketProvider
 } from '../../src';
 import { EthersNetwork } from '../../src/util/const';
+import { loadAlchemyEnv } from '../test-util';
 
 jest.setTimeout(50000);
 /**
@@ -21,7 +22,10 @@ describe('AlchemyProvider', () => {
   let ethersProvider: EthersAlchemyProvider;
 
   beforeEach(async () => {
-    alchemy = new Alchemy();
+    await loadAlchemyEnv();
+    alchemy = new Alchemy({
+      apiKey: process.env.ALCHEMY_API_KEY
+    });
     ethersProvider = new EthersAlchemyProvider(
       EthersNetwork[alchemy.config.network],
       alchemy.config.apiKey

--- a/test/integration/transact.test.ts
+++ b/test/integration/transact.test.ts
@@ -4,14 +4,16 @@ import {
   Network,
   Wallet
 } from '../../src';
-import { TESTING_PRIVATE_KEY } from '../test-util';
+import { TESTING_PRIVATE_KEY, loadAlchemyEnv } from '../test-util';
 
 jest.setTimeout(50000);
 describe('E2E integration tests', () => {
   let alchemy: Alchemy;
 
   beforeAll(async () => {
+    await loadAlchemyEnv();
     alchemy = await new Alchemy({
+      apiKey: process.env.ALCHEMY_API_KEY,
       network: Network.ETH_MAINNET
     });
   });

--- a/test/integration/wallet.test.ts
+++ b/test/integration/wallet.test.ts
@@ -1,13 +1,15 @@
 import { Wallet as EthersWallet } from '@ethersproject/wallet';
 
 import { Alchemy, Network, Wallet } from '../../src';
-import { TEST_WALLET_PRIVATE_KEY } from '../test-util';
+import { TEST_WALLET_PRIVATE_KEY, loadAlchemyEnv } from '../test-util';
 
 describe('Alchemy-Ethers Wallet', () => {
   let alchemy: Alchemy;
 
   beforeAll(async () => {
+    await loadAlchemyEnv();
     const settings = {
+      apiKey: process.env.ALCHEMY_API_KEY,
       network: Network.ETH_MAINNET
     };
     alchemy = new Alchemy(settings);


### PR DESCRIPTION
Changing to use alchemy.env's api key in tests since `demo` key can sometimes be rate-limited.