### PR TITLE
Refactor RawBaseNft to also include contract address.

### DIFF
--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -37,7 +37,6 @@ import { paginateEndpoint, requestHttpWithBackoff } from './dispatch';
 import {
   RawBaseNft,
   RawContractBaseNft,
-  RawContractNft,
   RawGetBaseNftsForContractResponse,
   RawGetBaseNftsResponse,
   RawGetNftsForContractResponse,
@@ -71,7 +70,7 @@ export async function getNftMetadata(
       tokenUriTimeoutInMs
     }
   );
-  return getNftFromRaw(response, contractAddress);
+  return getNftFromRaw(response);
 }
 
 export async function getContractMetadata(
@@ -171,7 +170,7 @@ export async function getNftsForContract(
 
   return {
     nfts: response.nfts.map(res =>
-      nftFromGetNftNftContractResponse(res, contractAddress)
+      nftFromGetNftContractResponse(res, contractAddress)
     ),
     pageKey: response.nextToken
   };
@@ -197,10 +196,8 @@ export async function* getNftsForContractIterator(
       withMetadata
     }
   )) {
-    for (const nft of response.nfts as
-      | RawContractBaseNft[]
-      | RawContractNft[]) {
-      yield nftFromGetNftNftContractResponse(nft, contractAddress);
+    for (const nft of response.nfts as RawContractBaseNft[] | RawNft[]) {
+      yield nftFromGetNftContractResponse(nft, contractAddress);
     }
   }
 }
@@ -468,7 +465,7 @@ async function refresh(
       refreshCache: true
     }
   );
-  return getNftFromRaw(response, contractAddress);
+  return getNftFromRaw(response);
 }
 
 /**
@@ -481,9 +478,9 @@ function nftFromGetNftResponse(
   ownedNft: RawOwnedBaseNft | RawOwnedNft
 ): Nft | BaseNft {
   if (isNftWithMetadata(ownedNft)) {
-    return getNftFromRaw(ownedNft, ownedNft.contract.address);
+    return getNftFromRaw(ownedNft);
   } else {
-    return getBaseNftFromRaw(ownedNft, ownedNft.contract.address);
+    return getBaseNftFromRaw(ownedNft);
   }
 }
 
@@ -493,12 +490,12 @@ function nftFromGetNftResponse(
  *
  * @internal
  */
-function nftFromGetNftNftContractResponse(
-  ownedNft: RawContractBaseNft | RawContractNft,
+function nftFromGetNftContractResponse(
+  ownedNft: RawContractBaseNft | RawNft,
   contractAddress: string
 ): Nft | BaseNft {
   if (isNftWithMetadata(ownedNft)) {
-    return getNftFromRaw(ownedNft, contractAddress);
+    return getNftFromRaw(ownedNft);
   } else {
     return getBaseNftFromRaw(ownedNft, contractAddress);
   }
@@ -506,7 +503,9 @@ function nftFromGetNftNftContractResponse(
 
 /** @internal */
 // TODO: more comprehensive type check
-function isNftWithMetadata(response: RawBaseNft | RawNft): response is RawNft {
+function isNftWithMetadata(
+  response: RawBaseNft | RawContractBaseNft | RawNft
+): response is RawNft {
   return (response as RawNft).title !== undefined;
 }
 

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -29,7 +29,6 @@ import { AlchemyApiType } from '../util/const';
 import {
   getBaseNftFromRaw,
   getNftContractFromRaw,
-  getNftContractsFromRaw,
   getNftFromRaw,
   getNftRarityFromRaw
 } from '../util/util';
@@ -389,7 +388,7 @@ export async function searchContractMetadata(
     query
   });
 
-  return getNftContractsFromRaw(response);
+  return response.map(getNftContractFromRaw);
 }
 
 export async function summarizeNftAttributes(

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -1,3 +1,4 @@
+import { BaseNftContract } from '../api/nft';
 import {
   Media,
   NftMetadata,
@@ -18,6 +19,7 @@ import {
  * @internal
  */
 export interface RawBaseNft {
+  contract: BaseNftContract;
   id: RawNftId;
 }
 
@@ -173,7 +175,7 @@ export interface RawGetBaseNftsForContractResponse {
  * @internal
  */
 export interface RawGetNftsForContractResponse {
-  nfts: RawContractNft[];
+  nfts: RawNft[];
   nextToken?: string;
 }
 
@@ -181,19 +183,15 @@ export interface RawGetNftsForContractResponse {
  * Represents the `nfts` field from the Alchemy HTTP response when calling the
  * `getNftsForNftContract` endpoint without metadata.
  *
+ * The main difference between {@link RawContractBaseNft} and
+ * {@link RawBaseNft} is that `RawContractBaseNft` omits the `contract` field
+ * in the payload since the method takes in a contract address param.
+ *
  * @internal
  */
 export interface RawContractBaseNft {
   id: RawNftId;
 }
-
-/**
- * Represents the `nfts` field from the Alchemy HTTP response when calling the
- * `getNftsForNftContract` endpoint with metadata.
- *
- * @internal
- */
-export interface RawContractNft extends RawNft, RawContractBaseNft {}
 
 /**
  * Represents Alchemy's HTTP response for `getOwnersForNftContract`.

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -73,14 +73,6 @@ export function getNftContractFromRaw(
   return contract;
 }
 
-export function getNftContractsFromRaw(
-  rawNftContracts: RawNftContract[]
-): NftContract[] {
-  return rawNftContracts.map(rawNftContract =>
-    getNftContractFromRaw(rawNftContract)
-  );
-}
-
 export function getBaseNftFromRaw(rawBaseNft: RawBaseNft): BaseNft;
 export function getBaseNftFromRaw(
   rawContractBaseNft: RawContractBaseNft,

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -5,6 +5,7 @@ import { toHex } from '../api/util';
 import {
   RawBaseNft,
   RawBaseNftContract,
+  RawContractBaseNft,
   RawNft,
   RawNftAttributeRarity,
   RawNftContract,
@@ -80,23 +81,30 @@ export function getNftContractsFromRaw(
   );
 }
 
+export function getBaseNftFromRaw(rawBaseNft: RawBaseNft): BaseNft;
 export function getBaseNftFromRaw(
-  rawBaseNft: RawBaseNft,
+  rawContractBaseNft: RawContractBaseNft,
   contractAddress: string
+): BaseNft;
+export function getBaseNftFromRaw(
+  rawBaseNft: RawBaseNft | RawContractBaseNft,
+  contractAddress?: string
 ): BaseNft {
   return {
-    contract: { address: contractAddress },
+    contract: contractAddress
+      ? { address: contractAddress }
+      : (rawBaseNft as RawBaseNft).contract,
     tokenId: BigNumber.from(rawBaseNft.id.tokenId).toString(),
     tokenType: parseNftTokenType(rawBaseNft.id.tokenMetadata?.tokenType)
   };
 }
 
-export function getNftFromRaw(rawNft: RawNft, contractAddress: string): Nft {
+export function getNftFromRaw(rawNft: RawNft): Nft {
   const tokenType = parseNftTokenType(rawNft.id.tokenMetadata?.tokenType);
   const spamInfo = parseSpamInfo(rawNft.spamInfo);
   return {
     contract: {
-      address: contractAddress,
+      address: rawNft.contract.address,
       name: rawNft.contractMetadata?.name,
       symbol: rawNft.contractMetadata?.symbol,
       totalSupply: rawNft.contractMetadata?.totalSupply,

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -97,10 +97,12 @@ export function createOwnedBaseNft(
 }
 
 export function createRawBaseNft(
+  contractAddress: string,
   tokenId: string | number,
   tokenType = NftTokenType.UNKNOWN
 ): RawBaseNft {
   return {
+    contract: { address: contractAddress },
     id: {
       tokenId: BigNumber.from(tokenId).toString(),
       tokenMetadata: { tokenType }
@@ -113,7 +115,7 @@ export function createBaseNft(
   tokenId: string | number,
   tokenType = NftTokenType.UNKNOWN
 ): BaseNft {
-  return getBaseNftFromRaw(createRawBaseNft(tokenId, tokenType), address);
+  return getBaseNftFromRaw(createRawBaseNft(address, tokenId, tokenType));
 }
 
 export function createNft(
@@ -125,8 +127,7 @@ export function createNft(
   media?: TokenUri[] | undefined
 ): Nft {
   return getNftFromRaw(
-    createRawNft(title, tokenId, tokenType, { tokenUri, media }),
-    address
+    createRawNft(address, title, tokenId, tokenType, { tokenUri, media })
   );
 }
 
@@ -139,12 +140,14 @@ interface RawNftOptions {
 }
 
 export function createRawNft(
+  contractAddress: string,
   title: string,
   tokenId: string,
   tokenType = NftTokenType.UNKNOWN,
   options?: RawNftOptions
 ): RawNft {
   return {
+    contract: { address: contractAddress },
     title,
     description: options?.description ?? `a truly unique NFT: ${title}`,
     timeLastUpdated: options?.timeLastUpdated ?? '2022-02-16T17:12:00.280Z',
@@ -169,7 +172,7 @@ export function createRawOwnedNft(
   contractMetadata?: RawNftContractMetadata
 ): RawOwnedNft {
   return {
-    ...createRawNft(title, tokenId, tokenType),
+    ...createRawNft(address, title, tokenId, tokenType),
     contract: {
       address
     },

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -2,7 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 import {
   BaseNft,
-  BaseNftContract,
   Nft,
   NftContract,
   NftTokenType,
@@ -13,7 +12,6 @@ import {
 } from '../src';
 import {
   RawBaseNft,
-  RawBaseNftContract,
   RawContractBaseNft,
   RawNft,
   RawNftContract,
@@ -23,11 +21,7 @@ import {
   RawOwnedNft
 } from '../src/internal/raw-interfaces';
 import { BlockHead, LogsEvent } from '../src/internal/websocket-backfiller';
-import {
-  getBaseNftContractFromRaw,
-  getBaseNftFromRaw,
-  getNftFromRaw
-} from '../src/util/util';
+import { getBaseNftFromRaw, getNftFromRaw } from '../src/util/util';
 
 export const TEST_WALLET_PRIVATE_KEY =
   'dd5bdf09397b1fdf98e4f72c66047d5104b1511fa7dc1b8fdddd61a150f732c9';
@@ -53,14 +47,6 @@ export function createRawNftContract(
       openSea
     }
   };
-}
-
-export function createRawBaseNftContract(address: string): RawBaseNftContract {
-  return { address };
-}
-
-export function createBaseNftContract(address: string): BaseNftContract {
-  return getBaseNftContractFromRaw(createRawBaseNftContract(address));
 }
 
 export function createRawOwnedBaseNft(
@@ -172,17 +158,7 @@ export function createRawOwnedNft(
   contractMetadata?: RawNftContractMetadata
 ): RawOwnedNft {
   return {
-    ...createRawNft(address, title, tokenId, tokenType),
-    contract: {
-      address
-    },
-    id: {
-      tokenId,
-      tokenMetadata: {
-        tokenType
-      }
-    },
-    contractMetadata,
+    ...createRawNft(address, title, tokenId, tokenType, { contractMetadata }),
     balance
   };
 }
@@ -217,7 +193,8 @@ export function verifyNftContractMetadata(
   name: string,
   symbol: string,
   totalSupply: string,
-  tokenType?: NftTokenType
+  tokenType?: NftTokenType,
+  openSea?: RawOpenSeaCollectionMetadata
 ) {
   expect(actualNftContract).toEqual(expectedNftContract);
   expect(actualNftContract.address).toEqual(address);
@@ -225,6 +202,26 @@ export function verifyNftContractMetadata(
   expect(actualNftContract.symbol).toEqual(symbol);
   expect(actualNftContract.totalSupply).toEqual(totalSupply);
   expect(actualNftContract.tokenType).toEqual(tokenType);
+
+  if (openSea) {
+    expect(actualNftContract.openSea?.floorPrice).toEqual(openSea.floorPrice);
+    expect(actualNftContract.openSea?.collectionName).toEqual(
+      openSea.collectionName
+    );
+    expect(actualNftContract.openSea?.safelistRequestStatus).toEqual(
+      openSea.safelistRequestStatus
+    );
+    expect(actualNftContract.openSea?.imageUrl).toEqual(openSea.imageUrl);
+    expect(actualNftContract.openSea?.description).toEqual(openSea.description);
+    expect(actualNftContract.openSea?.externalUrl).toEqual(openSea.externalUrl);
+    expect(actualNftContract.openSea?.twitterUsername).toEqual(
+      openSea.twitterUsername
+    );
+    expect(actualNftContract.openSea?.discordUrl).toEqual(openSea.discordUrl);
+    expect(actualNftContract.openSea?.lastIngestedAt).toEqual(
+      openSea.lastIngestedAt
+    );
+  }
 }
 
 export type Mocked<T> = T & {

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -9,7 +9,6 @@ import {
   GetOwnersForContractWithTokenBalancesResponse,
   Nft,
   NftAttributesResponse,
-  NftContract,
   NftContractBaseNftsResponse,
   NftContractNftsResponse,
   NftExcludeFilters,
@@ -97,58 +96,6 @@ describe('NFT module', () => {
       mock.onGet().reply(200, rawNftContractResponse);
     });
 
-    function verifyNftContractMetadata(
-      actualNftContract: NftContract,
-      expectedNftContract: NftContract,
-      address: string,
-      name: string,
-      symbol: string,
-      totalSupply: string,
-      tokenType?: NftTokenType,
-      openSea?: RawOpenSeaCollectionMetadata
-    ) {
-      expect(actualNftContract).toEqual(expectedNftContract);
-
-      expect(actualNftContract.address).toEqual(address);
-      expect(actualNftContract.name).toEqual(name);
-      expect(actualNftContract.symbol).toEqual(symbol);
-      expect(actualNftContract.totalSupply).toEqual(totalSupply);
-      expect(actualNftContract.tokenType).toEqual(tokenType);
-      if (openSea) {
-        expect(actualNftContract.openSea?.floorPrice).toEqual(
-          openSea.floorPrice
-        );
-        expect(actualNftContract.openSea?.collectionName).toEqual(
-          openSea.collectionName
-        );
-        expect(actualNftContract.openSea?.safelistRequestStatus).toEqual(
-          openSea.safelistRequestStatus
-        );
-        expect(actualNftContract.openSea?.imageUrl).toEqual(openSea.imageUrl);
-        expect(actualNftContract.openSea?.description).toEqual(
-          openSea.description
-        );
-        expect(actualNftContract.openSea?.externalUrl).toEqual(
-          openSea.externalUrl
-        );
-        expect(actualNftContract.openSea?.twitterUsername).toEqual(
-          openSea.twitterUsername
-        );
-        expect(actualNftContract.openSea?.discordUrl).toEqual(
-          openSea.discordUrl
-        );
-        expect(actualNftContract.openSea?.lastIngestedAt).toEqual(
-          openSea.lastIngestedAt
-        );
-      }
-
-      expect(mock.history.get.length).toEqual(1);
-      expect(mock.history.get[0].params).toHaveProperty(
-        'contractAddress',
-        address
-      );
-    }
-
     it('returns the api response in the expected format', async () => {
       verifyNftContractMetadata(
         await alchemy.nft.getContractMetadata(address),
@@ -158,6 +105,12 @@ describe('NFT module', () => {
         symbol,
         totalSupply,
         tokenType
+      );
+
+      expect(mock.history.get.length).toEqual(1);
+      expect(mock.history.get[0].params).toHaveProperty(
+        'contractAddress',
+        address
       );
     });
 

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -177,8 +177,12 @@ describe('NFT module', () => {
     const timeoutInMs = 50;
     // Special case token ID as an integer string, since that's what the NFT
     // API endpoint returns.
-    const rawNftResponse = createRawNft(title, tokenId.toString());
-    const expectedNft = getNftFromRaw(rawNftResponse, contractAddress);
+    const rawNftResponse = createRawNft(
+      contractAddress,
+      title,
+      tokenId.toString()
+    );
+    const expectedNft = getNftFromRaw(rawNftResponse);
 
     beforeEach(() => {
       mock.onGet().reply(200, rawNftResponse);
@@ -648,8 +652,8 @@ describe('NFT module', () => {
 
     const nftResponse: RawGetNftsForContractResponse = {
       nfts: [
-        createRawNft('a', '0x1', NftTokenType.ERC1155),
-        createRawNft('b', '0x2', NftTokenType.ERC1155)
+        createRawNft(contractAddress, 'a', '0x1', NftTokenType.ERC1155),
+        createRawNft(contractAddress, 'b', '0x2', NftTokenType.ERC1155)
       ],
       nextToken: 'page-key1'
     };
@@ -752,24 +756,26 @@ describe('NFT module', () => {
     it('includes contract metadata at the top level', async () => {
       const mockResponse = {
         nfts: [
-          createRawNft('a', '0x1', NftTokenType.UNKNOWN, {
+          createRawNft('0xCA1', 'title', '0x1', NftTokenType.UNKNOWN, {
             contractMetadata: {
               name: 'Super NFT',
               symbol: 'WOW',
               totalSupply: '9999'
             }
           }),
-          createRawNft('b', '0x2', NftTokenType.ERC1155)
+          createRawNft('0xCA1', 'b', '0x2', NftTokenType.ERC1155)
         ]
       };
       mock.reset();
       mock.onGet().reply(200, mockResponse);
       const response = await alchemy.nft.getNftsForContract(contractAddress);
       expect(response.nfts.length).toEqual(2);
+      expect(response.nfts[0].contract.address).toEqual('0xCA1');
       expect(response.nfts[0].contract.tokenType).toEqual(NftTokenType.UNKNOWN);
       expect(response.nfts[0].contract.name).toEqual('Super NFT');
       expect(response.nfts[0].contract.symbol).toEqual('WOW');
       expect(response.nfts[0].contract.totalSupply).toEqual('9999');
+      expect(response.nfts[1].contract.address).toEqual('0xCA1');
       expect(response.nfts[1].contract.tokenType).toEqual(NftTokenType.ERC1155);
       expect(response.nfts[1].contract.name).toBeUndefined();
       expect(response.nfts[1].contract.symbol).toBeUndefined();
@@ -795,13 +801,13 @@ describe('NFT module', () => {
     const nftResponses: RawGetNftsForContractResponse[] = [
       {
         nfts: [
-          createRawNft('a', '0x1', NftTokenType.ERC721),
-          createRawNft('b', '0x2', NftTokenType.ERC721)
+          createRawNft(contractAddress, 'a', '0x1', NftTokenType.ERC721),
+          createRawNft(contractAddress, 'b', '0x2', NftTokenType.ERC721)
         ],
         nextToken: 'page-key1'
       },
       {
-        nfts: [createRawNft('c', '0x3', NftTokenType.ERC721)]
+        nfts: [createRawNft(contractAddress, 'c', '0x3', NftTokenType.ERC721)]
       }
     ];
 
@@ -1411,12 +1417,14 @@ describe('NFT module', () => {
     const tokenId = '66';
     const tokenIdHex = '0x42';
     const rawNftResponse = createRawNft(
+      contractAddress,
       'title',
       tokenIdHex,
       NftTokenType.UNKNOWN,
       { timeLastUpdated: originalTimestamp }
     );
     const rawNftResponseRefreshed = createRawNft(
+      contractAddress,
       'title',
       tokenIdHex,
       NftTokenType.UNKNOWN,

--- a/test/unit/nft.test.ts
+++ b/test/unit/nft.test.ts
@@ -7,20 +7,18 @@ describe('BaseNft class', () => {
   const tokenId = '0x01';
   const tokenIdString = '1';
   it('fromResponse() defaults to UNKNOWN token type and normalizes capitalization', () => {
-    let nft = getBaseNftFromRaw(createRawBaseNft(tokenId), contractAddress);
+    let nft = getBaseNftFromRaw(createRawBaseNft(contractAddress, tokenId));
     expect(nft.tokenType).toEqual(NftTokenType.UNKNOWN);
     expect(nft.tokenId).toEqual(tokenIdString);
     expect(nft.contract.address).toEqual(contractAddress);
 
     nft = getBaseNftFromRaw(
-      createRawBaseNft(tokenId, 'erc721' as NftTokenType),
-      contractAddress
+      createRawBaseNft(contractAddress, tokenId, 'erc721' as NftTokenType)
     );
     expect(nft.tokenType).toEqual(NftTokenType.ERC721);
 
     nft = getBaseNftFromRaw(
-      createRawBaseNft(tokenId, 'ERC721' as NftTokenType),
-      contractAddress
+      createRawBaseNft(contractAddress, tokenId, 'ERC721' as NftTokenType)
     );
     expect(nft.tokenType).toEqual(NftTokenType.ERC721);
   });
@@ -28,12 +26,11 @@ describe('BaseNft class', () => {
   it('fromResponse() normalizes tokenId fields', () => {
     const tokenIdIntegerAsString = '42';
     const tokenIdHex = toHex(42);
-    let nft = getBaseNftFromRaw(createRawBaseNft(tokenIdHex), contractAddress);
+    let nft = getBaseNftFromRaw(createRawBaseNft(contractAddress, tokenIdHex));
     expect(nft.tokenId).toEqual(tokenIdIntegerAsString);
 
     nft = getBaseNftFromRaw(
-      createRawBaseNft(tokenIdIntegerAsString),
-      contractAddress
+      createRawBaseNft(contractAddress, tokenIdIntegerAsString)
     );
     expect(nft.tokenId).toEqual(tokenIdIntegerAsString);
   });
@@ -45,22 +42,29 @@ describe('Nft class', () => {
   const tokenIdString = '1';
   it('fromResponse() defaults to UNKNOWN token type', () => {
     let nft = getNftFromRaw(
-      createRawNft('title', toHex(tokenId)),
-      contractAddress
+      createRawNft(contractAddress, 'title', toHex(tokenId))
     );
     expect(nft.tokenType).toEqual(NftTokenType.UNKNOWN);
     expect(nft.tokenId).toEqual(tokenIdString);
     expect(nft.contract.address).toEqual(contractAddress);
 
     nft = getNftFromRaw(
-      createRawNft('title', toHex(tokenId), 'erc721' as NftTokenType),
-      contractAddress
+      createRawNft(
+        contractAddress,
+        'title',
+        toHex(tokenId),
+        'erc721' as NftTokenType
+      )
     );
     expect(nft.tokenType).toEqual(NftTokenType.ERC721);
 
     nft = getNftFromRaw(
-      createRawNft('title', toHex(tokenId), 'ERC721' as NftTokenType),
-      contractAddress
+      createRawNft(
+        contractAddress,
+        'title',
+        toHex(tokenId),
+        'ERC721' as NftTokenType
+      )
     );
     expect(nft.tokenType).toEqual(NftTokenType.ERC721);
   });
@@ -68,12 +72,11 @@ describe('Nft class', () => {
   it('fromResponse() normalizes tokenId fields', () => {
     const tokenIdIntegerAsString = '42';
     const tokenIdHex = toHex(42);
-    let nft = getNftFromRaw(createRawNft('title', tokenIdHex), contractAddress);
+    let nft = getNftFromRaw(createRawNft(contractAddress, 'title', tokenIdHex));
     expect(nft.tokenId).toEqual(tokenIdIntegerAsString);
 
     nft = getNftFromRaw(
-      createRawNft('title', tokenIdIntegerAsString),
-      contractAddress
+      createRawNft(contractAddress, 'title', tokenIdIntegerAsString)
     );
     expect(nft.tokenId).toEqual(tokenIdIntegerAsString);
   });
@@ -107,12 +110,18 @@ describe('Nft class', () => {
   it('constructor merges descriptions when it is an array', () => {
     const description = ['very', 'special', 'and unique', 'description'];
 
-    const rawNft = createRawNft('title', tokenIdString, NftTokenType.ERC721, {
-      tokenUri: { raw: '', gateway: '' },
-      timeLastUpdated: '2022-02-16T17:12:00.280Z',
-      description
-    });
-    const nft = getNftFromRaw(rawNft, '0xCA1');
+    const rawNft = createRawNft(
+      '0xCA1',
+      'title',
+      tokenIdString,
+      NftTokenType.ERC721,
+      {
+        tokenUri: { raw: '', gateway: '' },
+        timeLastUpdated: '2022-02-16T17:12:00.280Z',
+        description
+      }
+    );
+    const nft = getNftFromRaw(rawNft);
     expect(nft.description).toEqual('very special and unique description');
   });
 


### PR DESCRIPTION
The backend now returns the contract address for NFTs in responses when `withMetadata=false` on the `getNFTsForCollection` endpoint. This means that the SDK no longer has to manually pass in a separate contract address when creating BaseNft objects.

However, we still need to manage the distinction between `RawBaseNft` and `RawContractBaseNft` since the `getNFTsForCollection` endpoint still omits the contract address in the the without metadata response since all NFTs returned are under the same contract address.