### PR TITLE
Move BaseNft comments to method docs, not general docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,17 +208,6 @@ under the `alchemy.nft` namespace:
 - `summarizeNftAttributes()`: Get the summary of attribute prevalence for all NFTs in a contract.
 - `searchContractMetadata()`: Search for a keyword across metadata of all ERC-721 and ERC-1155 smart contracts.
 
-### Using `BaseNft` and `Nft`
-
-The SDK currently uses the `BaseNft` and `Nft` classes to represent NFTs returned by the Alchemy. The `BaseNft` object
-does
-not hold any metadata information and only contains the NFT contract and token ID. The `Nft` object additionally
-contains the NFT metadata, token URI information, and media.
-
-By default, the SDK will return the `Nft` object. You can optionally choose to fetch the `BaseNft` object instead by
-setting the `omitMetadata` parameter to `true`. The SDK documentation describes the different parameter and response
-interfaces in more detail.
-
 ### Pagination
 
 The Alchemy NFT endpoints return 100 results per page. To get the next page, you can pass in the `pageKey` returned by

--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -10,6 +10,10 @@ import {
 /**
  * Alchemy representation of a base NFT contract that doesn't contain metadata.
  *
+ * The BaseNftContract does not hold any metadata information and only contains
+ * the address. The NftContract additionally contains the tokenType, name,
+ * symbol, and more.
+ *
  * @public
  */
 export interface BaseNftContract {
@@ -19,6 +23,10 @@ export interface BaseNftContract {
 
 /**
  * Alchemy representation of an NFT contract.
+ *
+ * The BaseNftContract does not hold any metadata information and only contains
+ * the address. The NftContract additionally contains the tokenType, name,
+ * symbol, and more.
  *
  * @public
  */
@@ -36,7 +44,11 @@ export interface NftContract extends BaseNftContract {
 }
 
 /**
- * Alchemy representation of a base NFT that doesn't contain metadata.
+ * Alchemy representation of an NFT that doesn't contain metadata.
+ *
+ * The BaseNft object does not hold any metadata information and only contains
+ * the NFT contract and token ID. The Nft object additionally contains the NFT
+ * metadata, token URI information, and media.
  *
  * @public
  */
@@ -50,6 +62,10 @@ export interface BaseNft {
 
 /**
  * Alchemy representation of an NFT.
+ *
+ * The BaseNft object does not hold any metadata information and only contains
+ * the NFT contract and token ID. The Nft object additionally contains the NFT
+ * metadata, token URI information, and media.
  *
  * @public
  */


### PR DESCRIPTION
Reason: too niche for the general docs (which are quickly becoming too verbose).