### PR TITLE
Fix broken newHeads backfill

### DIFF
--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -400,15 +400,7 @@ export class AlchemyWebSocketProvider
       };
     });
 
-    const response = await this.sendBatchConcurrently(payload);
-    const errorResponse = response.find(r => !!r.error);
-    if (errorResponse) {
-      throw new Error(errorResponse.error!.message);
-    }
-    // The ids are ascending numbers because that's what Payload Factories do.
-    return response
-      .sort((r1, r2) => (r1.id as number) - (r2.id as number))
-      .map(r => r.result);
+    return this.sendBatchConcurrently(payload);
   }
 
   /** @override */
@@ -768,7 +760,7 @@ export class AlchemyWebSocketProvider
   // TODO(errors): Use allSettled() once we have more error handling.
   private async sendBatchConcurrently(
     payload: JsonRpcRequest[]
-  ): Promise<JsonRpcResponse[]> {
+  ): Promise<unknown[]> {
     return Promise.all(payload.map(req => this.send(req.method, req.params)));
   }
 

--- a/src/internal/websocket-backfiller.ts
+++ b/src/internal/websocket-backfiller.ts
@@ -253,13 +253,8 @@ export class WebsocketBackfiller {
       });
     }
 
-    // TODO: just fire off each send() separately since we're no longer batching:
     // TODO: handle errors
-    const batchedBlockHeads = await this.provider.sendBatch(batchParts);
-    const blockHeads = batchedBlockHeads.reduce(
-      (acc, batch) => acc.concat(batch),
-      []
-    );
+    const blockHeads = await this.provider.sendBatch(batchParts);
     return blockHeads.map(toNewHeadsEvent);
   }
 


### PR DESCRIPTION
newHeads were failing to backfill because of a misuse of the return value of `sendBatch`. Fix this up.