### PR TITLE
Fix reconnections for other subscription types

### DIFF
--- a/src/api/alchemy-websocket-provider.ts
+++ b/src/api/alchemy-websocket-provider.ts
@@ -548,7 +548,12 @@ export class AlchemyWebSocketProvider
         break;
       }
       default:
-        break;
+        if (physicalId !== virtualId) {
+          // In the case of a re-opened subscription, ethers will not emit the
+          // event, so the SDK has to.
+          const { result } = (message as SubscriptionEvent<unknown>).params;
+          this.emitEvent(virtualId, result);
+        }
     }
   };
 
@@ -700,7 +705,10 @@ export class AlchemyWebSocketProvider
     getBlockNumber: (result: T) => number
   ): void {
     this.rememberEvent(virtualId, result, getBlockNumber);
+    this.emitEvent(virtualId, result);
+  }
 
+  private emitEvent<T>(virtualId: string, result: T): void {
     const subscription = this.virtualSubscriptionsById.get(virtualId);
     if (!subscription) {
       return;


### PR DESCRIPTION
Subscription reconnections were only working for `newHeads` and `logs` subscriptions because of a missing case for the other types. Now all subscription types will reconnect when the connection drops.