### PR TITLE
Add tokenUriTimeout for getNftsForContract()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Minor Changes
 
+- Added the `tokenUriTimeoutInMs` option to `NftNamespace.getNftsForContract()` to specify the timeout duration for fetching an NFT's underlying metadata.
+
 ## 2.2.5
 
 ### Major Changes

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -207,7 +207,7 @@ export async function getNftsForContract(
     startToken: options?.pageKey,
     withMetadata,
     limit: options?.pageSize ?? undefined,
-    tokenUriTimeoutInMs: 50
+    tokenUriTimeoutInMs: options?.tokenUriTimeoutInMs
   });
 
   return {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1302,6 +1302,14 @@ export interface GetBaseNftsForContractOptions {
    * Maximum page size is 100.
    */
   pageSize?: number;
+
+  /**
+   * No set timeout by default - When metadata is requested, this parameter is
+   * the timeout (in milliseconds) for the website hosting the metadata to
+   * respond. If you want to only access the cache and not live fetch any
+   * metadata for cache misses then set this value to 0.
+   */
+  tokenUriTimeoutInMs?: number;
 }
 
 /**


### PR DESCRIPTION
Fixing a bug where the SDK always hard-coded the token uri timeout to 50ms.