### PR TITLE
Fix bug with AlchemySubscriptions.PENDING_TRANSACTIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor Changes
 
 - Added the `tokenUriTimeoutInMs` option to `NftNamespace.getNftsForContract()` to specify the timeout duration for fetching an NFT's underlying metadata.
+- Fixed a bug where using `AlchemySubscriptions.PENDING_TRANSACTIONS` with a string array input would throw an error (#222).
 
 ## 2.2.5
 

--- a/src/api/websocket-namespace.ts
+++ b/src/api/websocket-namespace.ts
@@ -162,7 +162,9 @@ export class WebSocketNamespace {
           );
         } else {
           eventName.fromAddress = await Promise.all(
-            eventName.fromAddress.map(this._resolveNameOrError)
+            eventName.fromAddress.map(address =>
+              this._resolveNameOrError(address)
+            )
           );
         }
       }
@@ -173,7 +175,9 @@ export class WebSocketNamespace {
           );
         } else {
           eventName.toAddress = await Promise.all(
-            eventName.toAddress.map(this._resolveNameOrError)
+            eventName.toAddress.map(address =>
+              this._resolveNameOrError(address)
+            )
           );
         }
       }


### PR DESCRIPTION
Fixes #222.

Underlying cause was passing in lambda function attached to `this`, which became `undefined` from the calling context.