### PR TITLE
feat(timeout): adding configurable requestTimeout for axios requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added the `tokenUriTimeoutInMs` option to `NftNamespace.getNftsForContract()` to specify the timeout duration for fetching an NFT's underlying metadata.
 - Fixed a bug where using `AlchemySubscriptions.PENDING_TRANSACTIONS` with a string array input would throw an error (#222).
 - Added support for the `refreshCache` option in `NftNamespace.getNftMetadata()`. This option is now available when using the `options` overload. The original method without the `options` overload is now deprecated.
-- Added support for the `requestTimeout` option in the `AlchemySettings` object to configure a timeout for `NftNamespace` and `NotifyNamespace` methods.
+- Added support for the `requestTimeout` option in the `AlchemySettings` object to configure a timeout for `NftNamespace` and `NotifyNamespace` methods. Thanks @Abbaskt!
 
 ## 2.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the `tokenUriTimeoutInMs` option to `NftNamespace.getNftsForContract()` to specify the timeout duration for fetching an NFT's underlying metadata.
 - Fixed a bug where using `AlchemySubscriptions.PENDING_TRANSACTIONS` with a string array input would throw an error (#222).
 - Added support for the `refreshCache` option in `NftNamespace.getNftMetadata()`. This option is now available when using the `options` overload. The original method without the `options` overload is now deprecated.
+- Added support for the `requestTimeout` option in the `AlchemySettings` object to configure a timeout for `NftNamespace` and `NotifyNamespace` methods.
 
 ## 2.2.5
 

--- a/src/api/alchemy-config.ts
+++ b/src/api/alchemy-config.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ALCHEMY_API_KEY,
   DEFAULT_MAX_RETRIES,
   DEFAULT_NETWORK,
+  DEFAULT_REQUEST_TIMEOUT,
   getAlchemyHttpUrl,
   getAlchemyNftHttpUrl,
   getAlchemyWebhookHttpUrl
@@ -40,6 +41,11 @@ export class AlchemyConfig {
   readonly authToken?: string;
 
   /**
+   * The optional Request timeout provided in `ms` for NFT and NOTIFY API. Defaults to 0.
+   */
+  readonly requestTimeout?: number;
+
+  /**
    * Dynamically imported provider instance.
    *
    * @internal
@@ -62,6 +68,7 @@ export class AlchemyConfig {
     this.url = config?.url;
     this.authToken = config?.authToken;
     this.batchRequests = config?.batchRequests || false;
+    this.requestTimeout = config?.requestTimeout || DEFAULT_REQUEST_TIMEOUT;
   }
 
   /**

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -57,6 +57,7 @@ export class Alchemy {
    * @param {string} [settings.apiKey] - The API key to use for Alchemy
    * @param {Network} [settings.network] - The network to use for Alchemy
    * @param {number} [settings.maxRetries] - The maximum number of retries to attempt
+   * @param {number} [settings.requestTimeout] - The timeout after which request should fail
    * @public
    */
   constructor(settings?: AlchemySettings) {

--- a/src/internal/dispatch.ts
+++ b/src/internal/dispatch.ts
@@ -41,7 +41,10 @@ export async function requestHttpWithBackoff<Req, Res>(
         restApiName,
         methodName,
         params,
-        overrides
+        {
+          ...overrides,
+          timeout: config.requestTimeout
+        }
       );
 
       if (response.status === 200) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -48,6 +48,12 @@ export interface AlchemySettings {
   authToken?: string;
 
   /**
+   * Optional Request timeout provided in `ms` while using NFT and NOTIFY API.
+   * Default to 0 (No timeout).
+   */
+  requestTimeout?: number;
+
+  /**
    * Optional setting that automatically batches and sends json-rpc requests for
    * higher throughput and reduced network IO. Defaults to false.
    *

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -5,6 +5,7 @@ import { Network } from '../types/types';
 export const DEFAULT_ALCHEMY_API_KEY = 'demo';
 export const DEFAULT_NETWORK = Network.ETH_MAINNET;
 export const DEFAULT_MAX_RETRIES = 5;
+export const DEFAULT_REQUEST_TIMEOUT = 0; // 0 = no timeout
 
 /**
  * Returns the base URL for making Alchemy API requests. The `alchemy.com`


### PR DESCRIPTION
Fixes #167

Timeout can be added while initializing the Alchemy object
```javascript
const alchemy = new Alchemy({
    requestTimeout: 10,
});
```
The above example set a timeout of `10ms` to any requests going through Axios.