### PR TITLE
Fixed excludeZeroValue docs to be the same as API

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -236,7 +236,7 @@ export interface AssetTransfersParams {
 
   /**
    * Whether to exclude transfers with zero value. Note that zero value is
-   * different than null value. Defaults to `false` if omitted.
+   * different than null value. Defaults to `true` if omitted.
    */
   excludeZeroValue?: boolean;
 


### PR DESCRIPTION
Fixed alchemy_getAssetTransfers excludeZeroValue docs to be the same as the API where excludeZeroValue is said to default to `true` ([link](https://docs.alchemy.com/reference/alchemy-getassettransfers)).