### PR TITLE
Add protocolFee to getNftSales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `NftNamespace.getMintedNfts()` to fetch all the NFTs an owner address minted, optionally filtered by a set of specific NFT contracts.
 - Added support for passing in a null `tokenId` when using NFT Webhook Filters, which allows you to listen to all token ids in a collection.
 - Added the option to pass in an `EventFilter` with multiple addresses to the `CoreNamespace.getLogs()` method.
-- Fixed a bug where the `protocolFee` was not included the response for `NftNamespace.getNftSales()`. Deprecated the existing `marketplaceFee` property in favor of the new `protocolFee` property.
+- Fixed a bug where the `protocolFee` was not included in the response for `NftNamespace.getNftSales()`. Deprecated the existing `marketplaceFee` property in favor of the new `protocolFee` property.
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `NftNamespace.getMintedNfts()` to fetch all the NFTs an owner address minted, optionally filtered by a set of specific NFT contracts.
 - Added support for passing in a null `tokenId` when using NFT Webhook Filters, which allows you to listen to all token ids in a collection.
 - Added the option to pass in an `EventFilter` with multiple addresses to the `CoreNamespace.getLogs()` method.
+- Fixed a bug where the `protocolFee` was not included the response for `NftNamespace.getNftSales()`. Deprecated the existing `marketplaceFee` property in favor of the new `protocolFee` property.
 
 ## 2.3.0
 

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -291,7 +291,7 @@ export interface RawNftSale {
   sellerAddress: string;
   taker: string;
   sellerFee: NftSaleFeeData;
-  marketplaceFee?: NftSaleFeeData;
+  protocolFee?: NftSaleFeeData;
   royaltyFee?: NftSaleFeeData;
   blockNumber: number;
   logIndex: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1089,8 +1089,14 @@ export interface NftSale {
   /** The payment from buyer to the seller. */
   sellerFee: NftSaleFeeData;
 
-  /** The payment from buyer to the marketplace. */
+  /**
+   * The payment from buyer to the marketplace.
+   * @deprecated Please use `protocolFee` instead.
+   */
   marketplaceFee?: NftSaleFeeData;
+
+  /** The payment from buyer to the marketplace. */
+  protocolFee?: NftSaleFeeData;
 
   /** The payment from buyer to the royalty address of the NFT collection. */
   royaltyFee?: NftSaleFeeData;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -110,6 +110,7 @@ export function getNftFromRaw(rawNft: RawNft): Nft {
 export function getNftSalesFromRaw(
   rawNftSales: RawGetNftSalesResponse
 ): GetNftSalesResponse {
+  console.log('raw', rawNftSales);
   return {
     pageKey: rawNftSales?.pageKey,
     nftSales: rawNftSales.nftSales.map(rawNftSale => ({
@@ -121,7 +122,8 @@ export function getNftSalesFromRaw(
       sellerAddress: rawNftSale.sellerAddress,
       taker: parseNftTaker(rawNftSale.taker),
       sellerFee: rawNftSale?.sellerFee,
-      marketplaceFee: rawNftSale?.marketplaceFee,
+      marketplaceFee: rawNftSale?.protocolFee,
+      protocolFee: rawNftSale?.protocolFee,
       royaltyFee: rawNftSale?.royaltyFee,
       blockNumber: rawNftSale?.blockNumber,
       logIndex: rawNftSale.logIndex,

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -110,7 +110,6 @@ export function getNftFromRaw(rawNft: RawNft): Nft {
 export function getNftSalesFromRaw(
   rawNftSales: RawGetNftSalesResponse
 ): GetNftSalesResponse {
-  console.log('raw', rawNftSales);
   return {
     pageKey: rawNftSales?.pageKey,
     nftSales: rawNftSales.nftSales.map(rawNftSale => ({

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -1,5 +1,6 @@
 import {
   Alchemy,
+  GetNftSalesResponse,
   NftContract,
   NftFilters,
   NftSaleMarketplace,
@@ -43,6 +44,30 @@ describe('E2E integration tests', () => {
     ).toEqual(true);
     expect(typeof metadata.contractDeployer).toEqual('string');
     expect(typeof metadata.deployedBlockNumber).toEqual('number');
+  }
+
+  function verifyNftSalesData(response: GetNftSalesResponse): void {
+    expect(response.nftSales.length).toBeGreaterThan(0);
+    expect(response.nftSales[0].bundleIndex).toBeDefined();
+    expect(typeof response.nftSales[0].bundleIndex).toEqual('number');
+    expect(response.nftSales[0].buyerAddress).toBeDefined();
+    expect(typeof response.nftSales[0].buyerAddress).toEqual('string');
+    expect(response.nftSales[0].contractAddress).toBeDefined();
+    expect(typeof response.nftSales[0].contractAddress).toEqual('string');
+    expect(response.nftSales[0].logIndex).toBeDefined();
+    expect(typeof response.nftSales[0].logIndex).toEqual('number');
+    expect(response.nftSales[0].marketplace).toBeDefined();
+    expect(typeof response.nftSales[0].logIndex).toEqual('number');
+    expect(response.nftSales[0].quantity).toBeDefined();
+    expect(typeof response.nftSales[0].quantity).toEqual('string');
+    expect(response.nftSales[0].sellerAddress).toBeDefined();
+    expect(typeof response.nftSales[0].sellerAddress).toEqual('string');
+    expect(response.nftSales[0].taker).toBeDefined();
+    expect(typeof response.nftSales[0].taker).toEqual('string');
+    expect(response.nftSales[0].tokenId).toBeDefined();
+    expect(typeof response.nftSales[0].tokenId).toEqual('string');
+    expect(response.nftSales[0].transactionHash).toBeDefined();
+    expect(typeof response.nftSales[0].transactionHash).toEqual('string');
   }
 
   it('getNftMetadata()', async () => {
@@ -377,30 +402,26 @@ describe('E2E integration tests', () => {
   });
 
   it('getNftSales()', async () => {
-    const response = await alchemy.nft.getNftSales();
+    const response = await alchemy.nft.getNftSales({
+      contractAddress: '0xe785E82358879F061BC3dcAC6f0444462D4b5330',
+      tokenId: 44
+    });
 
     expect(response.pageKey).toBeDefined();
-    expect(response.nftSales.length).toBeGreaterThan(0);
-    expect(response.nftSales[0].bundleIndex).toBeDefined();
-    expect(typeof response.nftSales[0].bundleIndex).toEqual('number');
-    expect(response.nftSales[0].buyerAddress).toBeDefined();
-    expect(typeof response.nftSales[0].buyerAddress).toEqual('string');
-    expect(response.nftSales[0].contractAddress).toBeDefined();
-    expect(typeof response.nftSales[0].contractAddress).toEqual('string');
-    expect(response.nftSales[0].logIndex).toBeDefined();
-    expect(typeof response.nftSales[0].logIndex).toEqual('number');
-    expect(response.nftSales[0].marketplace).toBeDefined();
-    expect(typeof response.nftSales[0].logIndex).toEqual('number');
-    expect(response.nftSales[0].quantity).toBeDefined();
-    expect(typeof response.nftSales[0].quantity).toEqual('string');
-    expect(response.nftSales[0].sellerAddress).toBeDefined();
-    expect(typeof response.nftSales[0].sellerAddress).toEqual('string');
-    expect(response.nftSales[0].taker).toBeDefined();
-    expect(typeof response.nftSales[0].taker).toEqual('string');
-    expect(response.nftSales[0].tokenId).toBeDefined();
-    expect(typeof response.nftSales[0].tokenId).toEqual('string');
-    expect(response.nftSales[0].transactionHash).toBeDefined();
-    expect(typeof response.nftSales[0].transactionHash).toEqual('string');
+    verifyNftSalesData(response);
+  });
+
+  it('getNftSales() with token', async () => {
+    const response = await alchemy.nft.getNftSales({
+      contractAddress: '0xe785E82358879F061BC3dcAC6f0444462D4b5330',
+      tokenId: 44
+    });
+
+    verifyNftSalesData(response);
+    expect(response.nftSales[0].royaltyFee).toBeDefined();
+    expect(response.nftSales[0].marketplaceFee).toBeDefined();
+    expect(response.nftSales[0].protocolFee).toBeDefined();
+    expect(response.nftSales[0].sellerFee).toBeDefined();
   });
 
   it('getNftSales() with pageKey', async () => {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -219,7 +219,7 @@ export function createRawNftSale(
     contractAddress,
     logIndex: 392,
     marketplace,
-    marketplaceFee: feeData,
+    protocolFee: feeData,
     quantity: '2',
     royaltyFee: feeData,
     sellerFee: feeData,


### PR DESCRIPTION
`marketplaceFee` was renamed to `protocolFee` for `NftNamespace.getNftSales()`. This PR includes the field in the response, and marks the old `marketplaceFee` field as deprecated.