### PR TITLE
Add getTransfersForOwner and update getMintedNfts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Major Changes
 
 ### Minor Changes
+- Added the `NftNamespace.getTransfersForOwner()` method to get all NFT transfers to or from a provided owner address.
+- Deprecated the `GetMintedNftsResponse` interface in favor of the `TransfersNftResponse`. The `TransfersNftResponse` contains the same properties as the `GetMintedNftsResponse` and includes additional fields about the transfer.
 
 ## 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ under the `alchemy.nft` namespace:
 - `getOwnersForNft()`: Get all the owners for a given NFT contract address and a particular token ID.
 - `getOwnersForContract()`: Get all the owners for a given NFT contract address.
 - `getMintedNfts()`: Get all the NFTs minted by the owner address.
+- `getTransfersForOwner()`: Get all the NFT transfers for a given owner address.
 - `verifyNftOwnership()`: Check whether the provided owner address owns the provided NFT contract addresses.
 - `isSpamContract()`: Check whether the given NFT contract address is a spam contract as defined by Alchemy (see the [NFT API FAQ](https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/nft-api-faq#nft-spam-classification))
 - `getSpamContracts()`: Returns a list of all spam contracts marked by Alchemy.

--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -17,6 +17,7 @@ import {
   getOwnersForContract,
   getOwnersForNft,
   getSpamContracts,
+  getTransfersForOwner,
   isSpamContract,
   refreshContract,
   refreshNftMetadata,
@@ -31,7 +32,6 @@ import {
   GetContractsForOwnerResponse,
   GetFloorPriceResponse,
   GetMintedNftsOptions,
-  GetMintedNftsResponse,
   GetNftMetadataOptions,
   GetNftSalesOptions,
   GetNftSalesOptionsByContractAddress,
@@ -43,6 +43,8 @@ import {
   GetOwnersForContractWithTokenBalancesOptions,
   GetOwnersForContractWithTokenBalancesResponse,
   GetOwnersForNftResponse,
+  GetTransfersForOwnerOptions,
+  GetTransfersForOwnerTransferType,
   NftAttributeRarity,
   NftAttributesResponse,
   NftContractBaseNftsResponse,
@@ -54,7 +56,8 @@ import {
   OwnedBaseNftsResponse,
   OwnedNft,
   OwnedNftsResponse,
-  RefreshContractResult
+  RefreshContractResult,
+  TransfersNftResponse
 } from '../types/types';
 import { AlchemyConfig } from './alchemy-config';
 import { BaseNft, Nft, NftContract } from './nft';
@@ -360,6 +363,21 @@ export class NftNamespace {
   }
 
   /**
+   * Gets all NFT transfers for a given owner's address.
+   *
+   * @param owner The owner to get transfers for.
+   * @param category Whether to get transfers to or from the owner address.
+   * @param options Additional options for the request.
+   */
+  getTransfersForOwner(
+    owner: string,
+    category: GetTransfersForOwnerTransferType,
+    options?: GetTransfersForOwnerOptions
+  ): Promise<TransfersNftResponse> {
+    return getTransfersForOwner(this.config, owner, category, options);
+  }
+
+  /**
    * Get all the NFTs minted by a specified owner address.
    *
    * @param owner - Address for the NFT owner (can be in ENS format).
@@ -368,7 +386,7 @@ export class NftNamespace {
   async getMintedNfts(
     owner: string,
     options?: GetMintedNftsOptions
-  ): Promise<GetMintedNftsResponse> {
+  ): Promise<TransfersNftResponse> {
     return getMintedNfts(this.config, owner, options);
   }
 

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -347,7 +347,8 @@ export async function getMintedNfts(
     excludeZeroValue: true,
     contractAddresses: options?.contractAddresses,
     category,
-    maxCount: 100
+    maxCount: 100,
+    pageKey: options?.pageKey
   };
   const response = await getAssetTransfers(config, params, 'getMintedNfts');
   return getNftsForTransfers(config, response);
@@ -367,7 +368,8 @@ export async function getTransfersForOwner(
     excludeZeroValue: true,
     contractAddresses: options?.contractAddresses,
     category,
-    maxCount: 100
+    maxCount: 100,
+    pageKey: options?.pageKey
   };
 
   if (transferType === GetTransfersForOwnerTransferType.TO) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -964,6 +964,67 @@ export interface ContractForOwner extends NftContract {
 }
 
 /**
+ * The type of transfer for the request. Note that using `TO` will also include
+ * NFTs that were minted by the owner.
+ */
+export enum GetTransfersForOwnerTransferType {
+  'TO' = 'TO',
+  'FROM' = 'FROM'
+}
+
+/**
+ * Optional parameters object for the {@link NftNamespace.getTransfersForOwner} method.
+ */
+export interface GetTransfersForOwnerOptions {
+  /**
+   * List of NFT contract addresses to filter mints by. If omitted, defaults to
+   * all contract addresses.
+   */
+  contractAddresses?: string[];
+
+  /**
+   * Filter mints by ERC721 vs ERC1155 contracts. If omitted, defaults to all
+   * NFTs.
+   */
+  tokenType?: NftTokenType.ERC1155 | NftTokenType.ERC721;
+
+  /**
+   * Optional page key from an existing {@link TransfersNftResponse} to use for
+   * pagination.
+   */
+  pageKey?: string;
+}
+
+/**
+ * Response object for NFT methods that fetch NFTs that were transferred or
+ * minted (ex: {@link NftNamespace.getTransfersForOwner} or
+ * {@link NftNamespace.getMintedNfts}).
+ */
+export interface TransfersNftResponse {
+  /** An array of NFTs.*/
+  nfts: TransferredNft[];
+  /** Optional page key to use to fetch the next group of NFTs. */
+  pageKey?: string;
+}
+
+/**
+ * NFT with extra data for a single NFT that was transferred or minted.
+ */
+export interface TransferredNft extends Nft {
+  /**
+   * The address the NFT was from. For minted NFTs, this field is the set to
+   * `0x0000000000000000000000000000000000000000`.
+   **/
+  from: string;
+  /** The address the NFT was sent or minted to. */
+  to?: string;
+  /** The transaction hash where the transfer or mint occurred. */
+  transactionHash: string;
+  /** The block number as a hex string of when the transfer or mint occurred. */
+  blockNumber: string;
+}
+
+/**
  * Optional parameters object for the {@link NftNamespace.getMintedNfts} method.
  */
 export interface GetMintedNftsOptions {
@@ -980,12 +1041,15 @@ export interface GetMintedNftsOptions {
   tokenType?: NftTokenType.ERC1155 | NftTokenType.ERC721;
 
   /**
-   * Optional page key from an existing {@link GetMintedNftsResponse} to use for
+   * Optional page key from an existing {@link TransfersNftResponse} to use for
    * pagination.
    */
   pageKey?: string;
 }
 
+/**
+ * @deprecated Use {@link TransfersNftResponse} instead.
+ */
 export interface GetMintedNftsResponse {
   /** An array of the minted NFTs for the provided owner address. */
   nfts: Nft[];

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -325,7 +325,7 @@ describe('E2E integration tests', () => {
       pageKey: response.pageKey
     });
     expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
-    expect(response).not.toEqual(responseWithPageKey);
+    expect(response.nfts[0]).not.toStrictEqual(responseWithPageKey.nfts[0]);
 
     // Handles ERC1155 NFT mints.
     const response3 = await alchemy.nft.getMintedNfts('vitalik.eth', {
@@ -376,7 +376,7 @@ describe('E2E integration tests', () => {
       }
     );
     expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
-    expect(response).not.toEqual(responseWithPageKey);
+    expect(response.nfts[0]).not.toEqual(responseWithPageKey.nfts[0]);
 
     // Handles ERC1155 NFT transfers.
     const response3 = await alchemy.nft.getTransfersForOwner(

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -1,6 +1,7 @@
 import {
   Alchemy,
   GetNftSalesResponse,
+  GetTransfersForOwnerTransferType,
   NftContract,
   NftFilters,
   NftSaleMarketplace,
@@ -353,6 +354,69 @@ describe('E2E integration tests', () => {
     const response5 = await alchemy.nft.getMintedNfts('vitalik.eth', {
       contractAddresses
     });
+    const nftsWithAddress = response5.nfts.filter(nft =>
+      contractAddresses.includes(nft.contract.address)
+    );
+    expect(nftsWithAddress.length).toEqual(response5.nfts.length);
+  });
+
+  it('getTransfersForOwner()', async () => {
+    // Handles paging
+    const response = await alchemy.nft.getTransfersForOwner(
+      'vitalik.eth',
+      GetTransfersForOwnerTransferType.TO
+    );
+    expect(response.pageKey).toBeDefined();
+    expect(response.nfts.length).toBeGreaterThan(0);
+    const responseWithPageKey = await alchemy.nft.getTransfersForOwner(
+      'vitalik.eth',
+      GetTransfersForOwnerTransferType.TO,
+      {
+        pageKey: response.pageKey
+      }
+    );
+    expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
+    expect(response).not.toEqual(responseWithPageKey);
+
+    // Handles ERC1155 NFT transfers.
+    const response3 = await alchemy.nft.getTransfersForOwner(
+      'vitalik.eth',
+      GetTransfersForOwnerTransferType.TO,
+      {
+        tokenType: NftTokenType.ERC1155
+      }
+    );
+    const nfts1155 = response3.nfts.filter(
+      nft => nft.tokenType === NftTokenType.ERC1155
+    );
+    expect(nfts1155.length).toEqual(response3.nfts.length);
+
+    // Handles ERC721 NFT transfers.
+    const response4 = await alchemy.nft.getTransfersForOwner(
+      'vitalik.eth',
+      GetTransfersForOwnerTransferType.FROM,
+      {
+        tokenType: NftTokenType.ERC721
+      }
+    );
+    const nfts721 = response4.nfts.filter(
+      // Some 721 transfers are ingested as NftTokenType.UNKNOWN.
+      nft => nft.tokenType !== NftTokenType.ERC1155
+    );
+    expect(nfts721.length).toEqual(response4.nfts.length);
+
+    // Handles contract address specifying.
+    const contractAddresses = [
+      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
+      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
+    ];
+    const response5 = await alchemy.nft.getTransfersForOwner(
+      'vitalik.eth',
+      GetTransfersForOwnerTransferType.TO,
+      {
+        contractAddresses
+      }
+    );
     const nftsWithAddress = response5.nfts.filter(nft =>
       contractAddresses.includes(nft.contract.address)
     );

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1785,4 +1785,5 @@ describe('NFT module', () => {
 
   // TODO: Add unit tests once we've implemented MockProvider.
   describe('getMintedNfts()', () => {});
+  describe('getTransfersForOwner()', () => {});
 });


### PR DESCRIPTION
Summary of PR:
- Add `getTransfersForOwner()` to fetch all transfers to or from an owner address
- Update `getMintedNfts()` to return the new `TransferredNft` type which includes transfer metadata