### PR TITLE
Add getTokensForOwner()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Major Changes
 
 ### Minor Changes
+- Added the `CoreNamespace.getTokensForOwner()` method to get all the token balances and token metadata for a given address.
 
 ## 2.4.1
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ It also includes the majority of Alchemy Enhanced APIs, including:
 You will also find the following utility methods:
 
 - `findContractDeployer()`: Find the contract deployer and block number for a given contract address.
+- `getTokensForOwner()`: Get all token balances and metadata for a given owner address
 
 ### Accessing the full Ethers.js Provider
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -166,6 +166,74 @@ export interface TokenBalanceFailure {
 }
 
 /**
+ * Optional params to pass into {@link CoreNamespace.getTokensForOwner}.
+ */
+export interface GetTokensForOwnerOptions {
+  /**
+   * List of contract addresses to filter by. If omitted, defaults to
+   * {@link TokenBalanceType.ERC20}.
+   */
+  contractAddresses?: string[] | TokenBalanceType;
+  /**
+   * Optional page key from an existing {@link GetTokensForOwnerResponse} to use for
+   * pagination.
+   */
+  pageKey?: string;
+}
+
+/**
+ * Response object for {@link CoreNamespace.getTokensForOwner}.
+ */
+export interface GetTokensForOwnerResponse {
+  /** Owned tokens for the provided addresses along with relevant metadata. */
+  tokens: OwnedToken[];
+  /** Page key for the next page of results, if one exists. */
+  pageKey?: string;
+}
+
+/**
+ * Represents an owned token on a {@link GetTokensForOwnerResponse}.
+ */
+export interface OwnedToken {
+  /** The contract address of the token. */
+  contractAddress: string;
+  /**
+   * The raw value of the balance field as a hex string. This value is undefined
+   * if the {@link error} field is present.
+   */
+  rawBalance?: string;
+  /**
+   * The formatted value of the balance field as a hex string. This value is
+   * undefined if the {@link error} field is present, or if the `decimals` field=
+   * is undefined.
+   */
+  balance?: string;
+  /** */
+  /**
+   * The token's name. Is undefined if the name is not defined in the contract and
+   * not available from other sources.
+   */
+  name?: string;
+  /**
+   * The token's symbol. Is undefined if the symbol is not defined in the contract
+   * and not available from other sources.
+   */
+  symbol?: string;
+  /**
+   * The number of decimals of the token. Is undefined if not defined in the
+   * contract and not available from other sources.
+   */
+  decimals?: number;
+  /** URL link to the token's logo. Is undefined if the logo is not available. */
+  logo?: string;
+  /**
+   * Error from fetching the token balances. If this field is defined, none of
+   * the other fields will be defined.
+   */
+  error?: string;
+}
+
+/**
  * Response object for the {@link CoreNamespace.getTokenMetadata} method.
  *
  * @public

--- a/test/integration/core.test.ts
+++ b/test/integration/core.test.ts
@@ -134,4 +134,30 @@ describe('E2E integration tests', () => {
     });
     expect(logs.length).toEqual(88);
   });
+
+  it('getTokensForOwner()', async () => {
+    // Works with page key
+    const res = await alchemy.core.getTokensForOwner('vitalik.eth');
+    expect(res.pageKey).not.toBeUndefined();
+    const res2 = await alchemy.core.getTokensForOwner('vitalik.eth', {
+      pageKey: res.pageKey
+    });
+    expect(res.tokens[0]).not.toEqual(res2.tokens[0]);
+
+    // Works with DEFAULT_TOKENS
+    const res3 = await alchemy.core.getTokensForOwner('vitalik.eth', {
+      contractAddresses: TokenBalanceType.DEFAULT_TOKENS
+    });
+    expect(res3.tokens.length).toEqual(100);
+
+    // Works with custom contract addresses
+    const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const USDT_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+    const res4 = await alchemy.core.getTokensForOwner('vitalik.eth', {
+      contractAddresses: [USDC_ADDRESS, USDT_ADDRESS]
+    });
+    expect(res4.tokens.length).toEqual(2);
+    expect(res4.tokens[0].contractAddress).toEqual(USDC_ADDRESS);
+    expect(res4.tokens[1].contractAddress).toEqual(USDT_ADDRESS);
+  });
 });


### PR DESCRIPTION
This PR adds support for `getTokensForOwner()`, which takes the result `alchemy_getTokenBalances` and calls `alchemy_getTokenMetadata` for each one in a batch. Some other changes:
- Updates the return type to remove the need for developers to do `null` checking in the raw response
- Calculates formatted `balance` type with the number of `decimals` in the metadata.