### PR TITLE
Update NftContract to use v3

### DIFF
--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -43,7 +43,7 @@ export interface NftContract extends BaseNftContract {
    */
   totalSupply?: string;
   /** OpenSea's metadata for the contract. */
-  openSea?: OpenSeaCollectionMetadata;
+  openSeaMetadata?: OpenSeaCollectionMetadata;
   /** The address that deployed the NFT contract. */
   contractDeployer?: string;
   /** The block number the NFT contract deployed in. */

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -67,7 +67,13 @@ export interface RawBaseNftContract {
  */
 export interface RawNftContract {
   address: string;
-  contractMetadata: RawNftContractMetadata;
+  name?: string;
+  symbol?: string;
+  totalSupply?: string;
+  tokenType?: NftTokenType;
+  contractDeployer?: string;
+  deployedBlockNumber?: number;
+  openSeaMetadata?: RawOpenSeaCollectionMetadata;
 }
 
 /**
@@ -82,7 +88,7 @@ export interface RawNftContractMetadata {
   symbol?: string;
   totalSupply?: string;
   tokenType?: NftTokenType;
-  openSea?: RawOpenSeaCollectionMetadata;
+  openSeaMetadata?: RawOpenSeaCollectionMetadata;
   contractDeployer?: string;
   deployedBlockNumber?: number;
 }
@@ -307,13 +313,11 @@ export interface RawGetContractsForOwnerResponse {
   totalCount: number;
 }
 
-export interface RawContractForOwner
-  extends Omit<RawNftContractMetadata, 'openSea'> {
+export interface RawContractForOwner extends RawNftContractMetadata {
   address: string;
   totalBalance: number;
   numDistinctTokensOwned: number;
   isSpam: boolean;
   tokenId: string;
   media: Media;
-  opensea?: RawOpenSeaCollectionMetadata;
 }

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -18,7 +18,7 @@ export function getAlchemyHttpUrl(network: Network, apiKey: string): string {
 }
 
 export function getAlchemyNftHttpUrl(network: Network, apiKey: string): string {
-  return `https://${network}.g.alchemy.com/nft/v2/${apiKey}`;
+  return `https://${network}.g.alchemy.com/nft/v3/${apiKey}`;
 }
 
 export function getAlchemyWsUrl(network: Network, apiKey: string): string {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -47,13 +47,13 @@ export function getNftContractFromRaw(
 ): NftContract {
   return {
     address: rawNftContract.address,
-    name: rawNftContract.contractMetadata.name,
-    symbol: rawNftContract.contractMetadata.symbol,
-    totalSupply: rawNftContract.contractMetadata.totalSupply,
-    tokenType: parseNftTokenType(rawNftContract.contractMetadata.tokenType),
-    openSea: parseOpenSeaMetadata(rawNftContract.contractMetadata.openSea),
-    contractDeployer: rawNftContract.contractMetadata.contractDeployer,
-    deployedBlockNumber: rawNftContract.contractMetadata.deployedBlockNumber
+    name: rawNftContract.name,
+    symbol: rawNftContract.symbol,
+    totalSupply: rawNftContract.totalSupply,
+    tokenType: parseNftTokenType(rawNftContract.tokenType),
+    openSeaMetadata: parseOpenSeaMetadata(rawNftContract.openSeaMetadata),
+    contractDeployer: rawNftContract.contractDeployer,
+    deployedBlockNumber: rawNftContract.deployedBlockNumber
   };
 }
 
@@ -87,7 +87,9 @@ export function getNftFromRaw(rawNft: RawNft): Nft {
         symbol: rawNft.contractMetadata?.symbol,
         totalSupply: rawNft.contractMetadata?.totalSupply,
         tokenType,
-        openSea: parseOpenSeaMetadata(rawNft.contractMetadata?.openSea),
+        openSeaMetadata: parseOpenSeaMetadata(
+          rawNft.contractMetadata?.openSeaMetadata
+        ),
         contractDeployer: rawNft.contractMetadata?.contractDeployer,
         deployedBlockNumber: rawNft.contractMetadata?.deployedBlockNumber
       },
@@ -187,7 +189,7 @@ export function getContractsForOwnerFromRaw(
         tokenId: contract.tokenId,
         totalBalance: contract.totalBalance,
         name: contract.name,
-        openSea: parseOpenSeaMetadata(contract?.opensea),
+        openSeaMetadata: parseOpenSeaMetadata(contract?.openSeaMetadata),
         symbol: contract?.symbol,
         tokenType: parseNftTokenType(contract?.tokenType),
         contractDeployer: contract.contractDeployer,

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -37,11 +37,11 @@ describe('E2E integration tests', () => {
     expect(typeof metadata.symbol).toEqual('string');
     expect(metadata.tokenType).toEqual(NftTokenType.ERC721);
     expect(typeof metadata.name).toEqual('string');
-    expect(metadata.openSea).toBeDefined();
-    expect(metadata.openSea?.safelistRequestStatus).toBeDefined();
+    expect(metadata.openSeaMetadata).toBeDefined();
+    expect(metadata.openSeaMetadata!.safelistRequestStatus).toBeDefined();
     expect(
       Object.values(OpenSeaSafelistRequestStatus).includes(
-        metadata.openSea?.safelistRequestStatus!
+        metadata.openSeaMetadata?.safelistRequestStatus!
       )
     ).toEqual(true);
     expect(typeof metadata.contractDeployer).toEqual('string');
@@ -120,8 +120,9 @@ describe('E2E integration tests', () => {
       pageSize: 51
     });
     expect(
-      response.ownedNfts.filter(nft => nft.contract.openSea !== undefined)
-        .length
+      response.ownedNfts.filter(
+        nft => nft.contract.openSeaMetadata !== undefined
+      ).length
     ).toBeGreaterThan(0);
     expect(response.ownedNfts.length).toEqual(51);
     expect(typeof response.blockHash).toEqual('string');

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -41,9 +41,7 @@ export function createRawNftContract(
 ): RawNftContract {
   return {
     address,
-    contractMetadata: {
-      ...metadata
-    }
+    ...metadata
   };
 }
 
@@ -240,7 +238,7 @@ export function createRawContractForOwner(
   tokenType?: NftTokenType,
   symbol?: string,
   totalSupply?: string,
-  opensea?: RawOpenSeaCollectionMetadata,
+  openSeaMetadata?: RawOpenSeaCollectionMetadata,
   contractDeployer?: string,
   deployedBlockNumber?: number
 ): RawContractForOwner {
@@ -253,7 +251,7 @@ export function createRawContractForOwner(
     numDistinctTokensOwned: 1,
     name,
     totalSupply,
-    opensea,
+    openSeaMetadata,
     symbol,
     tokenType,
     contractDeployer,
@@ -293,21 +291,31 @@ export function verifyNftContractMetadata(
   expect(actualNftContract.tokenType).toEqual(tokenType);
 
   if (openSea) {
-    expect(actualNftContract.openSea?.floorPrice).toEqual(openSea.floorPrice);
-    expect(actualNftContract.openSea?.collectionName).toEqual(
+    expect(actualNftContract.openSeaMetadata?.floorPrice).toEqual(
+      openSea.floorPrice
+    );
+    expect(actualNftContract.openSeaMetadata?.collectionName).toEqual(
       openSea.collectionName
     );
-    expect(actualNftContract.openSea?.safelistRequestStatus).toEqual(
+    expect(actualNftContract.openSeaMetadata?.safelistRequestStatus).toEqual(
       openSea.safelistRequestStatus
     );
-    expect(actualNftContract.openSea?.imageUrl).toEqual(openSea.imageUrl);
-    expect(actualNftContract.openSea?.description).toEqual(openSea.description);
-    expect(actualNftContract.openSea?.externalUrl).toEqual(openSea.externalUrl);
-    expect(actualNftContract.openSea?.twitterUsername).toEqual(
+    expect(actualNftContract.openSeaMetadata?.imageUrl).toEqual(
+      openSea.imageUrl
+    );
+    expect(actualNftContract.openSeaMetadata?.description).toEqual(
+      openSea.description
+    );
+    expect(actualNftContract.openSeaMetadata?.externalUrl).toEqual(
+      openSea.externalUrl
+    );
+    expect(actualNftContract.openSeaMetadata?.twitterUsername).toEqual(
       openSea.twitterUsername
     );
-    expect(actualNftContract.openSea?.discordUrl).toEqual(openSea.discordUrl);
-    expect(actualNftContract.openSea?.lastIngestedAt).toEqual(
+    expect(actualNftContract.openSeaMetadata?.discordUrl).toEqual(
+      openSea.discordUrl
+    );
+    expect(actualNftContract.openSeaMetadata?.lastIngestedAt).toEqual(
       openSea.lastIngestedAt
     );
   }

--- a/test/unit/alchemy.test.ts
+++ b/test/unit/alchemy.test.ts
@@ -81,7 +81,7 @@ describe('Alchemy class', () => {
     });
 
     expect(alchemy.config._getRequestUrl(AlchemyApiType.NFT)).toEqual(
-      'https://opt-mainnet.g.alchemy.com/nft/v2/demo-key'
+      'https://opt-mainnet.g.alchemy.com/nft/v3/demo-key'
     );
     expect(alchemy.config._getRequestUrl(AlchemyApiType.BASE)).toEqual(
       'https://opt-mainnet.g.alchemy.com/v2/demo-key'

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -85,14 +85,14 @@ describe('NFT module', () => {
     const tokenType = NftTokenType.ERC721;
     const contractDeployer = '0xDEF';
     const deployedBlockNumber = 424242;
-    const openSea = createRawOpenSeaCollectionMetadata();
+    const openSeaMetadata = createRawOpenSeaCollectionMetadata();
 
     const rawNftContractResponse = createRawNftContract(address, {
       tokenType,
       name,
       symbol,
       totalSupply,
-      openSea,
+      openSeaMetadata,
       contractDeployer,
       deployedBlockNumber
     });
@@ -1240,7 +1240,9 @@ describe('NFT module', () => {
       expect(result.contracts[2].name).toEqual(name);
       expect(result.contracts[2].tokenType).toEqual(NftTokenType.ERC1155);
       expect(result.contracts[2].symbol).toEqual(symbol);
-      expect(result.contracts[2].openSea).toEqual(expectedOpenseaMetadata);
+      expect(result.contracts[2].openSeaMetadata).toEqual(
+        expectedOpenseaMetadata
+      );
       expect(result.contracts[2].totalSupply).toEqual(totalSupply);
     });
 


### PR DESCRIPTION
This PR updates:
- getContractForOwner()
- getContractMetadata()


Changes:
- Update to use v3 NFT url.
- Use new `openSeaMetadata` field
- Remove `contractMetadata` field