### PR TITLE
Fix NFT transfers API. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Minor Changes
 - Added a missing `gas` field in the `DebugTransaction` interface to specify the gas provided for a transaction execution.
+- Fixed a bug with `NftNamespace.getMintedNfts()`, `NftNamespace.getTransfersForOwner()`, and `NftNamespace.getTransfersForContract()` where the method would incorrectly error if the specified address had no transfers.
 
 ## 2.4.2
 

--- a/src/internal/nft-api.ts
+++ b/src/internal/nft-api.ts
@@ -770,6 +770,10 @@ async function getNftsForTransfers(
       return tokens.map(token => ({ metadata, token }));
     });
 
+  if (metadataTransfers.length === 0) {
+    return { nfts: [] };
+  }
+
   const nfts = await getNftMetadataBatch(
     config,
     metadataTransfers.map(transfer => transfer.token)

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -362,58 +362,6 @@ describe('E2E integration tests', () => {
     expect(nftsWithAddress.length).toEqual(response5.nfts.length);
   });
 
-  it('getMintedNfts()', async () => {
-    // Handles paging
-    const response = await alchemy.nft.getMintedNfts('vitalik.eth');
-    expect(response.pageKey).toBeDefined();
-    expect(response.nfts.length).toBeGreaterThan(0);
-    const responseWithPageKey = await alchemy.nft.getMintedNfts('vitalik.eth', {
-      pageKey: response.pageKey
-    });
-    expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
-    expect(response).not.toEqual(responseWithPageKey);
-
-    // Handles ERC1155 NFT mints.
-    const response3 = await alchemy.nft.getMintedNfts('vitalik.eth', {
-      tokenType: NftTokenType.ERC1155
-    });
-    const nfts1155 = response3.nfts.filter(
-      nft => nft.tokenType === NftTokenType.ERC1155
-    );
-    expect(nfts1155.length).toEqual(response3.nfts.length);
-
-    // // Handles ERC721 NFT mints.
-    const response4 = await alchemy.nft.getMintedNfts('vitalik.eth', {
-      tokenType: NftTokenType.ERC721
-    });
-    const nfts721 = response4.nfts.filter(
-      // Some 721 transfers are ingested as NftTokenType.UNKNOWN.
-      nft => nft.tokenType !== NftTokenType.ERC1155
-    );
-    expect(nfts721.length).toEqual(response4.nfts.length);
-
-    // Handles contract address specifying.
-    const contractAddresses = [
-      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
-      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
-    ];
-    const response5 = await alchemy.nft.getMintedNfts('vitalik.eth', {
-      contractAddresses
-    });
-    const nftsWithAddress = response5.nfts.filter(nft =>
-      contractAddresses.includes(nft.contract.address)
-    );
-    expect(nftsWithAddress.length).toEqual(response5.nfts.length);
-  });
-
-  it('testy', async () => {
-    const response = await alchemy.nft.getTransfersForOwner(
-      'brianchen.eth',
-      GetTransfersForOwnerTransferType.FROM
-    );
-    console.log(response);
-  });
-
   it('getTransfersForOwner()', async () => {
     // Handles paging
     const response = await alchemy.nft.getTransfersForOwner(

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -362,6 +362,58 @@ describe('E2E integration tests', () => {
     expect(nftsWithAddress.length).toEqual(response5.nfts.length);
   });
 
+  it('getMintedNfts()', async () => {
+    // Handles paging
+    const response = await alchemy.nft.getMintedNfts('vitalik.eth');
+    expect(response.pageKey).toBeDefined();
+    expect(response.nfts.length).toBeGreaterThan(0);
+    const responseWithPageKey = await alchemy.nft.getMintedNfts('vitalik.eth', {
+      pageKey: response.pageKey
+    });
+    expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
+    expect(response).not.toEqual(responseWithPageKey);
+
+    // Handles ERC1155 NFT mints.
+    const response3 = await alchemy.nft.getMintedNfts('vitalik.eth', {
+      tokenType: NftTokenType.ERC1155
+    });
+    const nfts1155 = response3.nfts.filter(
+      nft => nft.tokenType === NftTokenType.ERC1155
+    );
+    expect(nfts1155.length).toEqual(response3.nfts.length);
+
+    // // Handles ERC721 NFT mints.
+    const response4 = await alchemy.nft.getMintedNfts('vitalik.eth', {
+      tokenType: NftTokenType.ERC721
+    });
+    const nfts721 = response4.nfts.filter(
+      // Some 721 transfers are ingested as NftTokenType.UNKNOWN.
+      nft => nft.tokenType !== NftTokenType.ERC1155
+    );
+    expect(nfts721.length).toEqual(response4.nfts.length);
+
+    // Handles contract address specifying.
+    const contractAddresses = [
+      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
+      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
+    ];
+    const response5 = await alchemy.nft.getMintedNfts('vitalik.eth', {
+      contractAddresses
+    });
+    const nftsWithAddress = response5.nfts.filter(nft =>
+      contractAddresses.includes(nft.contract.address)
+    );
+    expect(nftsWithAddress.length).toEqual(response5.nfts.length);
+  });
+
+  it('testy', async () => {
+    const response = await alchemy.nft.getTransfersForOwner(
+      'brianchen.eth',
+      GetTransfersForOwnerTransferType.FROM
+    );
+    console.log(response);
+  });
+
   it('getTransfersForOwner()', async () => {
     // Handles paging
     const response = await alchemy.nft.getTransfersForOwner(


### PR DESCRIPTION
Fixed a bug with `NftNamespace.getMintedNfts()`, `NftNamespace.getTransfersForOwner()`, and `NftNamespace.getTransfersForContract()` where the method would incorrectly error if the specified address had no transfers.