### PR TITLE
Add NftMetadataUpdateWebhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Major Changes
 
+- Added the `NftMetadataUpdateWebhook` to be used with the `NotifyNamespace`. This webhook tracks all ERC721 and ERC1155 token metadata updates.
+
 ### Minor Changes
 
 ## 2.5.0

--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -24,6 +24,8 @@ import {
   NftActivityWebhook,
   NftFilter,
   NftFiltersResponse,
+  NftMetadataUpdateWebhook,
+  NftMetadataWebhookUpdate,
   NftWebhookParams,
   NftWebhookUpdate,
   TransactionWebhookParams,
@@ -179,6 +181,17 @@ export class NotifyNamespace {
   updateWebhook(nftWebhookId: string, update: NftWebhookUpdate): Promise<void>;
 
   /**
+   * Update a {@link NftMetadataUpdateWebhook}'s active status or NFT filters.
+   *
+   * @param nftMetadataWebhookId The id of the NFT activity webhook.
+   * @param update Object containing the update.
+   */
+  updateWebhook(
+    nftMetadataWebhookId: string,
+    update: NftMetadataWebhookUpdate
+  ): Promise<void>;
+
+  /**
    * Update a {@link AddressActivityWebhook}'s active status or addresses.
    *
    * @param addressWebhook The address activity webhook to update.
@@ -201,7 +214,7 @@ export class NotifyNamespace {
   ): Promise<void>;
   async updateWebhook(
     webhookOrId: NftActivityWebhook | AddressActivityWebhook | string,
-    update: NftWebhookUpdate | AddressWebhookUpdate
+    update: NftWebhookUpdate | AddressWebhookUpdate | NftMetadataWebhookUpdate
   ): Promise<void> {
     const webhookId =
       typeof webhookOrId === 'string' ? webhookOrId : webhookOrId.id;
@@ -228,6 +241,22 @@ export class NotifyNamespace {
           : [],
         nft_filters_to_remove: update.removeFilters
           ? update.removeFilters.map(nftFilterToParam)
+          : []
+      };
+    } else if (
+      'addMetadataFilters' in update ||
+      'removeMetadataFilters' in update
+    ) {
+      restApiName = 'update-webhook-nft-metadata-filters';
+      methodName = 'updateWebhookNftMetadataFilters';
+      method = 'PATCH';
+      data = {
+        webhook_id: webhookId,
+        nft_metadata_filters_to_add: update.addMetadataFilters
+          ? update.addMetadataFilters.map(nftFilterToParam)
+          : [],
+        nft_metadata_filters_to_remove: update.removeMetadataFilters
+          ? update.removeMetadataFilters.map(nftFilterToParam)
           : []
       };
     } else if ('addAddresses' in update || 'removeAddresses' in update) {
@@ -310,6 +339,12 @@ export class NotifyNamespace {
     params: NftWebhookParams
   ): Promise<NftActivityWebhook>;
 
+  createWebhook(
+    url: string,
+    type: WebhookType.NFT_METADATA_UPDATE,
+    params: NftWebhookParams
+  ): Promise<NftMetadataUpdateWebhook>;
+
   /**
    * Create a new {@link AddressActivityWebhook} to track address activity.
    *
@@ -332,6 +367,7 @@ export class NotifyNamespace {
     | DroppedTransactionWebhook
     | NftActivityWebhook
     | AddressActivityWebhook
+    | NftMetadataUpdateWebhook
   > {
     let appId;
     if (
@@ -345,9 +381,12 @@ export class NotifyNamespace {
     }
 
     let network = NETWORK_TO_WEBHOOK_NETWORK.get(this.config.network);
-    let filters;
+    let nftFilterObj;
     let addresses;
-    if (type === WebhookType.NFT_ACTIVITY) {
+    if (
+      type === WebhookType.NFT_ACTIVITY ||
+      type === WebhookType.NFT_METADATA_UPDATE
+    ) {
       if (!('filters' in params) || params.filters.length === 0) {
         throw new Error(
           'Nft Activity Webhooks require a non-empty array input.'
@@ -356,7 +395,7 @@ export class NotifyNamespace {
       network = params.network
         ? NETWORK_TO_WEBHOOK_NETWORK.get(params.network)
         : network;
-      filters = (params.filters as NftFilter[]).map(filter =>
+      const filters = (params.filters as NftFilter[]).map(filter =>
         filter.tokenId
           ? {
               contract_address: filter.contractAddress,
@@ -366,6 +405,10 @@ export class NotifyNamespace {
               contract_address: filter.contractAddress
             }
       );
+      nftFilterObj =
+        type === WebhookType.NFT_ACTIVITY
+          ? { nft_filters: filters }
+          : { nft_metadata_filters: filters };
     } else if (type === WebhookType.ADDRESS_ACTIVITY) {
       if (
         params === undefined ||
@@ -388,8 +431,8 @@ export class NotifyNamespace {
       webhook_url: url,
       ...(appId && { app_id: appId }),
 
-      // Only include the filters/addresses in the final response if it's defined
-      ...(filters && { nft_filters: filters }),
+      // Only include the filters/addresses in the final response if they're defined
+      ...(nftFilterObj && { ...nftFilterObj }),
       ...(addresses && { addresses })
     };
 

--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -432,7 +432,7 @@ export class NotifyNamespace {
       ...(appId && { app_id: appId }),
 
       // Only include the filters/addresses in the final response if they're defined
-      ...(nftFilterObj && { ...nftFilterObj }),
+      ...nftFilterObj,
       ...(addresses && { addresses })
     };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2109,7 +2109,8 @@ export enum WebhookType {
   MINED_TRANSACTION = 'MINED_TRANSACTION',
   DROPPED_TRANSACTION = 'DROPPED_TRANSACTION',
   ADDRESS_ACTIVITY = 'ADDRESS_ACTIVITY',
-  NFT_ACTIVITY = 'NFT_ACTIVITY'
+  NFT_ACTIVITY = 'NFT_ACTIVITY',
+  NFT_METADATA_UPDATE = 'NFT_METADATA_UPDATE'
 }
 
 /**
@@ -2146,6 +2147,15 @@ export interface AddressActivityWebhook extends Webhook {
  */
 export interface NftActivityWebhook extends Webhook {
   type: WebhookType.NFT_ACTIVITY;
+}
+
+/**
+ * The NFT Metadata Update Webhook tracks all ERC721 and ERC1155 metadata updates.
+ * This can be used to notify your app with real time state changes when an NFT's
+ * metadata changes.
+ */
+export interface NftMetadataUpdateWebhook extends Webhook {
+  type: WebhookType.NFT_METADATA_UPDATE;
 }
 
 /** The response for a {@link NotifyNamespace.getAllWebhooks} method. */
@@ -2193,7 +2203,7 @@ export interface TransactionWebhookParams {
 
 /**
  * Params to pass in when calling {@link NotifyNamespace.createWebhook} in order
- * to create a {@link NftActivityWebhook}.
+ * to create a {@link NftActivityWebhook} or {@link NftMetadataUpdateWebhook}.
  */
 export interface NftWebhookParams {
   /** Array of NFT filters the webhook should track. */
@@ -2219,7 +2229,7 @@ export interface AddressWebhookParams {
   network?: Network;
 }
 
-/** NFT to track on a {@link NftActivityWebhook}. */
+/** NFT to track on a {@link NftActivityWebhook} or {@link NftMetadataUpdateWebhook}. */
 export interface NftFilter {
   /** The contract address of the NFT. */
   contractAddress: string;
@@ -2262,6 +2272,17 @@ export interface WebhookNftFilterUpdate {
 
 /**
  * Params object when calling {@link NotifyNamespace.updateWebhook} to add and
+ * remove NFT filters for a {@link NftMetadataUpdateWebhook}.
+ */
+export interface WebhookNftMetadataFilterUpdate {
+  /** The filters to additionally track. */
+  addMetadataFilters: NftFilter[];
+  /** Existing filters to remove. */
+  removeMetadataFilters: NftFilter[];
+}
+
+/**
+ * Params object when calling {@link NotifyNamespace.updateWebhook} to add and
  * remove addresses for a {@link AddressActivityWebhook}.
  */
 export interface WebhookAddressUpdate {
@@ -2284,10 +2305,17 @@ export interface WebhookAddressOverride {
  * Params object when calling {@link NotifyNamespace.updateWebhook} to update a
  * {@link NftActivityWebhook}.
  */
-
 export type NftWebhookUpdate =
   | WebhookStatusUpdate
   | RequireAtLeastOne<WebhookNftFilterUpdate>;
+
+/**
+ * Params object when calling {@link NotifyNamespace.updateWebhook} to update a
+ * {@link NftMetadataUpdateWebhook}.
+ */
+export type NftMetadataWebhookUpdate =
+  | WebhookStatusUpdate
+  | RequireAtLeastOne<WebhookNftMetadataFilterUpdate>;
 
 /**
  * Params object when calling {@link NotifyNamespace.updateWebhook} to update a


### PR DESCRIPTION
This PR adds support for NFT Metadata Update Webhooks. You can read the full docs here: https://docs.alchemy.com/reference/nft-metadata-updates-webhook