### PR TITLE
Add title field to ContractForOwner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Minor Changes
 
+- Added the `title` field to `ContractForOwner` to represent the title of the token held by the owner.
+
 ## 2.6.0
 
 ### Major Changes

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -312,6 +312,7 @@ export interface RawContractForOwner
   address: string;
   totalBalance: number;
   numDistinctTokensOwned: number;
+  title: string;
   isSpam: boolean;
   tokenId: string;
   media: Media;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1029,6 +1029,9 @@ export interface ContractForOwner extends NftContract {
    */
   totalBalance: number;
 
+  /** The title of the token held by the owner. */
+  title: string;
+
   /**
    * Number of distinct token IDs held by the owner. For non-fungible tokens
    * this will be equal to the totalBalance, but it may be lower if the user

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -187,6 +187,7 @@ export function getContractsForOwnerFromRaw(
         tokenId: contract.tokenId,
         totalBalance: contract.totalBalance,
         name: contract.name,
+        title: contract.title,
         openSea: parseOpenSeaMetadata(contract?.opensea),
         symbol: contract?.symbol,
         tokenType: parseNftTokenType(contract?.tokenType),

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -242,7 +242,8 @@ export function createRawContractForOwner(
   totalSupply?: string,
   opensea?: RawOpenSeaCollectionMetadata,
   contractDeployer?: string,
-  deployedBlockNumber?: number
+  deployedBlockNumber?: number,
+  title = 'NFT Title'
 ): RawContractForOwner {
   return {
     address,
@@ -252,6 +253,7 @@ export function createRawContractForOwner(
     totalBalance: 1,
     numDistinctTokensOwned: 1,
     name,
+    title,
     totalSupply,
     opensea,
     symbol,

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1183,8 +1183,7 @@ describe('NFT module', () => {
           false,
           name,
           NftTokenType.ERC721,
-          symbol,
-          title
+          symbol
         ),
         createRawContractForOwner(
           contractAddress,
@@ -1234,7 +1233,6 @@ describe('NFT module', () => {
       expect(result.contracts[1].address).toEqual(contractAddress);
       expect(result.contracts[1].tokenId).toEqual(tokenId);
       expect(result.contracts[1].name).toEqual(name);
-      expect(result.contracts[1].title).toEqual(title);
       expect(result.contracts[1].tokenType).toEqual(NftTokenType.ERC721);
       expect(result.contracts[1].symbol).toEqual(symbol);
       expect(result.contracts[1].totalSupply).toBeUndefined();

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1155,6 +1155,7 @@ describe('NFT module', () => {
     const contractAddress = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d';
     const tokenId = '27';
     const name = 'NFT Contract Name';
+    const title = 'NFT Title';
     const symbol = 'XNO';
     const totalContractCount = 3;
     const totalSupply = '1492';
@@ -1182,7 +1183,8 @@ describe('NFT module', () => {
           false,
           name,
           NftTokenType.ERC721,
-          symbol
+          symbol,
+          title
         ),
         createRawContractForOwner(
           contractAddress,
@@ -1195,7 +1197,8 @@ describe('NFT module', () => {
           totalSupply,
           rawOpenSeaContractMetadata,
           contractDeployer,
-          deployedBlockNumber
+          deployedBlockNumber,
+          title
         )
       ]
     };
@@ -1231,6 +1234,7 @@ describe('NFT module', () => {
       expect(result.contracts[1].address).toEqual(contractAddress);
       expect(result.contracts[1].tokenId).toEqual(tokenId);
       expect(result.contracts[1].name).toEqual(name);
+      expect(result.contracts[1].title).toEqual(title);
       expect(result.contracts[1].tokenType).toEqual(NftTokenType.ERC721);
       expect(result.contracts[1].symbol).toEqual(symbol);
       expect(result.contracts[1].totalSupply).toBeUndefined();
@@ -1239,6 +1243,7 @@ describe('NFT module', () => {
       expect(result.contracts[2].address).toEqual(contractAddress);
       expect(result.contracts[2].tokenId).toEqual(tokenId);
       expect(result.contracts[2].name).toEqual(name);
+      expect(result.contracts[2].title).toEqual(title);
       expect(result.contracts[2].tokenType).toEqual(NftTokenType.ERC1155);
       expect(result.contracts[2].symbol).toEqual(symbol);
       expect(result.contracts[2].openSea).toEqual(expectedOpenseaMetadata);


### PR DESCRIPTION
Fixes #278.

This PR adds the `title` field to the `ContractForOwner` interface returned by `NftNamespace.getContractsForOwner`. The field represents the title of the NFT owned by the owner