### PR TITLE
Fix media field in ContractForOwner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Minor Changes
 
+- Fixed a bug where the `media` field in `ContractForOwner` was a `Media` object rather than a `Media[]` array.
+
 ## 2.6.0
 
 ### Major Changes

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -314,6 +314,6 @@ export interface RawContractForOwner
   numDistinctTokensOwned: number;
   isSpam: boolean;
   tokenId: string;
-  media: Media;
+  media: Media[];
   opensea?: RawOpenSeaCollectionMetadata;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1042,7 +1042,7 @@ export interface ContractForOwner extends NftContract {
   tokenId: string;
 
   /** Alternative NFT metadata for this contract to be parsed manually. */
-  media: Media;
+  media: Media[];
 }
 
 /**

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -234,7 +234,7 @@ export function createRawNftSale(
 export function createRawContractForOwner(
   address: string,
   tokenId: string,
-  media: Media,
+  media: Media[],
   isSpam?: boolean,
   name?: string,
   tokenType?: NftTokenType,
@@ -265,14 +265,16 @@ export function createNftMediaData(
   bytes?: number,
   format?: string,
   thumbnail?: string
-): Media {
-  return {
-    raw: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
-    gateway: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
-    bytes,
-    format,
-    thumbnail
-  };
+): Media[] {
+  return [
+    {
+      raw: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
+      gateway: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
+      bytes,
+      format,
+      thumbnail
+    }
+  ];
 }
 
 export function verifyNftContractMetadata(


### PR DESCRIPTION
The `media` field in `ContractForOwner` was incorrectly typed as a `Media` object. The REST API returns a `Media[]` object. This PR updates the TS typing to the correct return type.