### PR TITLE
Fix getTransfersForX() bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Minor Changes
 
 - Fixed a bug where the SDK was not compatible with `moduleResolution: bundler` when using `typescript` at `v5.0`(#302). Thanks @florrdv!
+- Fixed a bug with `getTransfersForOwner()` and `getTransfersForContract()` methods in the `NftNamespace`, where some NFTs would not be returned if the NFT was transferred multiple times.
 
 ## 2.8.0
 

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -473,67 +473,25 @@ describe('E2E integration tests', () => {
     expect(nftsWithAddress.length).toEqual(response5.nfts.length);
   });
 
-  it('getTransfersForOwner()', async () => {
-    // Handles paging
-    const response = await alchemy.nft.getTransfersForOwner(
-      'vitalik.eth',
-      GetTransfersForOwnerTransferType.TO
-    );
-    expect(response.pageKey).toBeDefined();
-    expect(response.nfts.length).toBeGreaterThan(0);
-    const responseWithPageKey = await alchemy.nft.getTransfersForOwner(
-      'vitalik.eth',
-      GetTransfersForOwnerTransferType.TO,
-      {
-        pageKey: response.pageKey
-      }
-    );
-    expect(responseWithPageKey.nfts.length).toBeGreaterThan(0);
-    expect(response.nfts[0]).not.toEqual(responseWithPageKey.nfts[0]);
+  it('getTransfersForContract() with multiple transfers for same token', async () => {
+    // This is a sanity test since this block range contains two transfers for
+    // the same token that will be included in the same NFT metadata batch.
+    const CONTRACT = '0x0cdd3cb3bcd969c2b389488b51fb093cc0d703b1';
+    const START_BLOCK = 16877400;
+    const END_BLOCK = 16877500;
 
-    // Handles ERC1155 NFT transfers.
-    const response3 = await alchemy.nft.getTransfersForOwner(
-      'vitalik.eth',
-      GetTransfersForOwnerTransferType.TO,
-      {
-        tokenType: NftTokenType.ERC1155
-      }
-    );
-    const nfts1155 = response3.nfts.filter(
-      nft => nft.tokenType === NftTokenType.ERC1155
-    );
-    expect(nfts1155.length).toEqual(response3.nfts.length);
+    const transactions = new Set<string>();
+    const transfers = await alchemy.nft.getTransfersForContract(CONTRACT, {
+      fromBlock: START_BLOCK,
+      toBlock: END_BLOCK
+    });
 
-    // Handles ERC721 NFT transfers.
-    const response4 = await alchemy.nft.getTransfersForOwner(
-      'vitalik.eth',
-      GetTransfersForOwnerTransferType.FROM,
-      {
-        tokenType: NftTokenType.ERC721
-      }
-    );
-    const nfts721 = response4.nfts.filter(
-      // Some 721 transfers are ingested as NftTokenType.UNKNOWN.
-      nft => nft.tokenType !== NftTokenType.ERC1155
-    );
-    expect(nfts721.length).toEqual(response4.nfts.length);
+    transfers.nfts
+      .filter(t => t.tokenId === '238')
+      .forEach(t => transactions.add(t.transactionHash));
+    console.log(transfers.nfts.length);
 
-    // Handles contract address specifying.
-    const contractAddresses = [
-      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
-      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
-    ];
-    const response5 = await alchemy.nft.getTransfersForOwner(
-      'vitalik.eth',
-      GetTransfersForOwnerTransferType.TO,
-      {
-        contractAddresses
-      }
-    );
-    const nftsWithAddress = response5.nfts.filter(nft =>
-      contractAddresses.includes(nft.contract.address)
-    );
-    expect(nftsWithAddress.length).toEqual(response5.nfts.length);
+    expect(transactions.size).toEqual(2);
   });
 
   it('getTransfersForContract()', async () => {


### PR DESCRIPTION
Fixed a bug with `getTransfersForOwner()` and `getTransfersForContract()` methods in the `NftNamespace`, where some NFTs would not be returned if the NFT was transferred multiple times.

`getNftMetdataBatch()` de-dupes tokens. This caused a bug where the if a batch contained the same token twice, the second token would not be hydrated with nft metadata.

Changes:
- Create a mapping of each token to the underlying NFT that is used to hydrate the transfer metadata
- Added an integration test to verify the behavior
- Deleted extra integration test that was a duplicate.