### PR TITLE
Move exports.default to the last field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Minor Changes
 
+- Moved the `exports.default` field to be the last field. This fixed a bug introduced in `2.8.1` that prevented certain frameworks from building (#313).
+
 ## 2.8.1
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
       "import": "./dist/cjs/index.js"
     },
     "package.json": "./package.json",
-    "default": "./dist/esm/index.js",
-    "types": "./dist/src/index.d.ts"
+    "types": "./dist/src/index.d.ts",
+    "default": "./dist/esm/index.js"
   },
   "types": "./dist/src/index.d.ts",
   "repository": {


### PR DESCRIPTION
Fixes #313.

Move `exports.default` to always be the last field. This fixes the bug in `v2.8.1` caused by #303. 

Tested locally with react and next apps. Verified that original issue in #303 is still fixed after this change.