### PR TITLE
Add Wallet.populateTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Minor Changes
 
 - Fixed a bug with `NotifyNamespace` when creating webhooks on ETH_SEPOLIA, OPT_GOERLI, and ARB_GOERLI.
+- Fixed a bug with `Wallet.populateTransaction()` where the method would never resolve.
 
 ## 2.8.2
 

--- a/src/api/alchemy-wallet.ts
+++ b/src/api/alchemy-wallet.ts
@@ -107,8 +107,25 @@ export class Wallet extends EthersWallet {
   }
 
   /**
+   * Populates ALL keys for a transaction and checks that `from` matches this
+   * `Signer`. Resolves ENS names and populates fields like `gasPrice`, `gasLimit`,
+   * `nonce`, and `chainId` if they are not provided.
+   *
+   * @param transaction The transaction to populate.
+   * @override
+   */
+  populateTransaction(
+    transaction: Deferrable<TransactionRequest>
+  ): Promise<TransactionRequest> {
+    return this.getWallet().then(wallet =>
+      wallet.populateTransaction(transaction)
+    );
+  }
+
+  /**
    * Populates all fields in a transaction, signs it and sends it to the network
    *
+   * @param transaction The transaction to send.
    * @override
    */
   sendTransaction(


### PR DESCRIPTION
Fixes #308.

`Wallet.populateTransaction()` in the base ethers calls uses the underlying provider to estimate the gas. If the provider promise is not plumbed through, the method will never resolve.