### PR TITLE
Use Promise.allSettled for getTokensForOwner metadata fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Minor Changes
 
+- Added redundancy to `CoreNamespace.getTokensForOwner()` to handle failures when fetching token metadata.
+
 ## 2.8.3
 
 ### Major Changes

--- a/src/api/core-namespace.ts
+++ b/src/api/core-namespace.ts
@@ -533,7 +533,7 @@ export class CoreNamespace {
       rawBalance: BigNumber.from(balance.tokenBalance!).toString()
     }));
 
-    const metadata: TokenMetadataResponse[] = await Promise.all(
+    const metadataPromises = await Promise.allSettled(
       response.tokenBalances.map(token =>
         provider._send(
           'alchemy_getTokenMetadata',
@@ -542,6 +542,16 @@ export class CoreNamespace {
           /* forceBatch= */ true
         )
       )
+    );
+    const metadata: TokenMetadataResponse[] = metadataPromises.map(p =>
+      p.status === 'fulfilled'
+        ? p.value
+        : {
+            name: null,
+            symbol: null,
+            decimals: null,
+            logo: null
+          }
     );
     const ownedTokens = formattedBalances.map((balance, index) => ({
       ...balance,


### PR DESCRIPTION
Fixes #323.

There's a backend component to this as well, where we're incorrectly flagging valid token contract addresses as invalid. Either way, we should be using Promise.allSettled here in case for more robustness 