### PR TITLE
Update response types in v3

### DIFF
--- a/src/api/nft-namespace.ts
+++ b/src/api/nft-namespace.ts
@@ -27,12 +27,15 @@ import {
   verifyNftOwnership
 } from '../internal/nft-api';
 import {
+  ComputeRarityResponse,
   GetBaseNftsForContractOptions,
   GetBaseNftsForOwnerOptions,
+  GetContractMetadataBatchResponse,
   GetContractsForOwnerOptions,
   GetContractsForOwnerResponse,
   GetFloorPriceResponse,
   GetMintedNftsOptions,
+  GetNftMetadataBatchResponse,
   GetNftMetadataOptions,
   GetNftSalesOptions,
   GetNftSalesOptionsByContractAddress,
@@ -45,10 +48,11 @@ import {
   GetOwnersForContractWithTokenBalancesResponse,
   GetOwnersForNftOptions,
   GetOwnersForNftResponse,
+  GetSpamContractsResponse,
   GetTransfersForContractOptions,
   GetTransfersForOwnerOptions,
   GetTransfersForOwnerTransferType,
-  NftAttributeRarity,
+  IsSpamContractResponse,
   NftAttributesResponse,
   NftContractBaseNftsResponse,
   NftContractNftsResponse,
@@ -60,6 +64,7 @@ import {
   OwnedNft,
   OwnedNftsResponse,
   RefreshContractResult,
+  SearchContractMetadataResponse,
   TransfersNftResponse
 } from '../types/types';
 import { AlchemyConfig } from './alchemy-config';
@@ -120,7 +125,7 @@ export class NftNamespace {
   getNftMetadataBatch(
     tokens: Array<NftMetadataBatchToken>,
     options?: NftMetadataBatchOptions
-  ): Promise<Nft[]> {
+  ): Promise<GetNftMetadataBatchResponse> {
     return getNftMetadataBatch(this.config, tokens, options);
   }
 
@@ -141,7 +146,7 @@ export class NftNamespace {
    */
   getContractMetadataBatch(
     contractAddresses: string[]
-  ): Promise<NftContract[]> {
+  ): Promise<GetContractMetadataBatchResponse> {
     return getContractMetadataBatch(this.config, contractAddresses);
   }
 
@@ -437,7 +442,7 @@ export class NftNamespace {
    * @param contractAddress - The contract address to check.
    * @beta
    */
-  isSpamContract(contractAddress: string): Promise<boolean> {
+  isSpamContract(contractAddress: string): Promise<IsSpamContractResponse> {
     return isSpamContract(this.config, contractAddress);
   }
 
@@ -448,7 +453,7 @@ export class NftNamespace {
    *
    * @beta
    */
-  getSpamContracts(): Promise<string[]> {
+  getSpamContracts(): Promise<GetSpamContractsResponse> {
     return getSpamContracts(this.config);
   }
 
@@ -487,7 +492,7 @@ export class NftNamespace {
   computeRarity(
     contractAddress: string,
     tokenId: BigNumberish
-  ): Promise<NftAttributeRarity[]> {
+  ): Promise<ComputeRarityResponse> {
     return computeRarity(this.config, contractAddress, tokenId);
   }
 
@@ -496,7 +501,9 @@ export class NftNamespace {
    *
    * @param query - The search string that you want to search for in contract metadata.
    */
-  searchContractMetadata(query: string): Promise<NftContract[]> {
+  searchContractMetadata(
+    query: string
+  ): Promise<SearchContractMetadataResponse> {
     return searchContractMetadata(this.config, query);
   }
 

--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -634,17 +634,12 @@ const WEBHOOK_NETWORK_TO_NETWORK: { [key: string]: Network } = {
   ETH_MAINNET: Network.ETH_MAINNET,
   ETH_GOERLI: Network.ETH_GOERLI,
   ETH_SEPOLIA: Network.ETH_SEPOLIA,
-  ETH_ROPSTEN: Network.ETH_ROPSTEN,
-  ETH_RINKEBY: Network.ETH_RINKEBY,
-  ETH_KOVAN: Network.ETH_KOVAN,
   MATIC_MAINNET: Network.MATIC_MAINNET,
   MATIC_MUMBAI: Network.MATIC_MUMBAI,
   ARB_MAINNET: Network.ARB_MAINNET,
   ARB_GOERLI: Network.ARB_GOERLI,
-  ARB_RINKEBY: Network.ARB_RINKEBY,
   OPT_MAINNET: Network.OPT_MAINNET,
-  OPT_GOERLI: Network.OPT_GOERLI,
-  OPT_KOVAN: Network.OPT_KOVAN
+  OPT_GOERLI: Network.OPT_GOERLI
 };
 
 /** Mapping of the SDK's network representation the webhook API's network representation. */

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -149,11 +149,12 @@ export interface RawContractBaseNft {
  * @internal
  */
 export interface RawGetOwnersForContractResponse {
-  ownerAddresses: string[];
+  owners: string[];
+  pageKey: string | null;
 }
 
 export interface RawGetOwnersForContractWithTokenBalancesResponse {
-  ownerAddresses: RawOwnerAddress[];
+  owners: RawOwnerAddress[];
   pageKey: string | null;
 }
 
@@ -227,10 +228,24 @@ export interface RawNftFilterParam {
   token_id?: string;
 }
 
+export interface RawSearchContractMetadataResponse {
+  contracts: RawNftContract[];
+}
+
+export interface RawComputeRarityResponse {
+  rarities: RawNftAttributeRarity[];
+}
+
 export interface RawNftAttributeRarity {
   value: string;
   traitType: string;
   prevalence: number;
+}
+
+export interface RawNftAttributesResponse {
+  summary: Record<string, Record<string, number>>;
+  totalSupply: string;
+  contractAddress: string;
 }
 
 export interface RawGetNftSalesResponse {
@@ -273,6 +288,22 @@ export interface RawNftContractForOwner
     RawNftContractOwnershipInfo {
   displayNft: RawDisplayNftForContract;
   image: RawNftImage;
+}
+
+export interface RawGetNftMetadataBatchResponse {
+  nfts: Array<RawNft>;
+}
+
+export interface RawGetContractMetadataBatchResponse {
+  contracts: RawNftContract[];
+}
+
+export interface RawIsSpamContractResponse {
+  isSpamContract: boolean;
+}
+
+export interface RawGetSpamContractsResponse {
+  contractAddresses: string[];
 }
 
 export interface RawDisplayNftForContract {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -841,6 +841,8 @@ export interface GetOwnersForNftResponse {
 export interface GetOwnersForContractResponse {
   /** An array of owner addresses for the provided contract address */
   owners: string[];
+  /** Optional page key that is returned when a collection has more than 50,000 owners. */
+  pageKey?: string;
 }
 
 /**
@@ -854,6 +856,15 @@ export interface GetOwnersForContractWithTokenBalancesResponse {
 
   /** Optional page key that is returned when a collection has more than 50,000 owners. */
   pageKey?: string;
+}
+
+export interface GetNftMetadataBatchResponse {
+  /** An array of NFT metadata objects. */
+  nfts: Nft[];
+}
+
+export interface GetContractMetadataBatchResponse {
+  contracts: NftContract[];
 }
 
 /**
@@ -877,6 +888,14 @@ export interface NftContractTokenBalance {
   tokenId: string;
   /** The token id balance for the provided owner. */
   balance: string;
+}
+
+export interface IsSpamContractResponse {
+  isSpamContract: boolean;
+}
+
+export interface GetSpamContractsResponse {
+  contractAddresses: string[];
 }
 
 /**
@@ -1347,6 +1366,17 @@ export enum NftSaleTakerType {
   SELLER = 'seller'
 }
 
+export interface SearchContractMetadataResponse {
+  contracts: NftContract[];
+}
+
+/**
+ * Response object for the {@link NftNamespace.computeRarity} method.
+ */
+export interface ComputeRarityResponse {
+  rarities: NftAttributeRarity[];
+}
+
 /**
  * Information about the rarity of an NFT's attribute in the specified collection.
  *
@@ -1376,7 +1406,7 @@ export interface NftAttributesResponse {
   contractAddress: string;
 
   /** The specified NFT contract's total supply. */
-  totalSupply: number;
+  totalSupply: string;
 
   /**
    * The attribute prevalence of each trait grouped by the trait type for the

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -75,21 +75,11 @@ export interface AlchemySettings {
  */
 export enum Network {
   ETH_MAINNET = 'eth-mainnet',
-  /** @deprecated - Will be removed in subsequent versions */
-  ETH_ROPSTEN = 'eth-ropsten',
   ETH_GOERLI = 'eth-goerli',
-  /** @deprecated - Will be removed in subsequent versions */
-  ETH_KOVAN = 'eth-kovan',
-  /** @deprecated - Will be removed in subsequent versions */
-  ETH_RINKEBY = 'eth-rinkeby',
   ETH_SEPOLIA = 'eth-sepolia',
   OPT_MAINNET = 'opt-mainnet',
-  /** @deprecated - Will be removed in subsequent versions */
-  OPT_KOVAN = 'opt-kovan',
   OPT_GOERLI = 'opt-goerli',
   ARB_MAINNET = 'arb-mainnet',
-  /** @deprecated - Will be removed in subsequent versions */
-  ARB_RINKEBY = 'arb-rinkeby',
   ARB_GOERLI = 'arb-goerli',
   MATIC_MAINNET = 'polygon-mainnet',
   MATIC_MUMBAI = 'polygon-mumbai',
@@ -378,19 +368,6 @@ export enum AssetTransfersCategory {
 }
 
 /**
- * Enum for the order of the {@link AssetTransfersParams} request object when
- * using {@link CoreNamespace.getAssetTransfers}.
- *
- * @deprecated Use {@link SortingOrder} instead. This enum will be removed in a
- *   future version.
- * @public
- */
-export enum AssetTransfersOrder {
-  ASCENDING = 'asc',
-  DESCENDING = 'desc'
-}
-
-/**
  * An enum for specifying the token type on NFTs.
  *
  * @public
@@ -547,42 +524,6 @@ export interface NftImage {
   originalUrl?: string;
 }
 
-/**
- * Represents the URI information for the NFT's media assets.
- *
- * @public
- */
-export interface Media {
-  /**
-   * URI for the location of the NFT's original metadata blob for media (ex: the
-   * original IPFS link).
-   */
-  raw: string;
-
-  /** Public gateway URI for the raw URI. Generally offers better performance. */
-  gateway: string;
-
-  /** URL for a resized thumbnail of the NFT media asset. */
-  thumbnail?: string;
-
-  /**
-   * The media format (ex: jpg, gif, png) of the {@link gateway} and
-   * {@link thumbnail} assets.
-   */
-  format?: string;
-
-  /**
-   * DEPRECATED - The size of the media asset in bytes
-   *
-   * @deprecated - Please use {@link bytes} instead. This field will be removed
-   *   in a subsequent release.
-   */
-  size?: number;
-
-  /** The size of the media asset in bytes. */
-  bytes?: number;
-}
-
 /** Potential reasons why an NFT contract was classified as spam. */
 export enum NftSpamClassification {
   Erc721TooManyOwners = 'Erc721TooManyOwners',
@@ -707,23 +648,6 @@ export interface GetBaseNftsForOwnerOptions {
    * contract address and token ID in lexicographic order.
    */
   orderBy?: NftOrdering;
-}
-
-/**
- * Enum of NFT filters that can be applied to a {@link getNftsForOwner} request.
- * NFTs that match one or more of these filters are excluded from the response.
- *
- * @deprecated Use {@link NftFilters} instead. This enum will be removed in a
- *   future version.
- *
- * @beta
- */
-export enum NftExcludeFilters {
-  /** Exclude NFTs that have been classified as spam. */
-  SPAM = 'SPAM',
-
-  /** Exclude NFTs that have been airdropped to a user. */
-  AIRDROPS = 'AIRDROPS'
 }
 
 /**
@@ -1184,17 +1108,6 @@ export interface GetMintedNftsOptions {
    * Optional page key from an existing {@link TransfersNftResponse} to use for
    * pagination.
    */
-  pageKey?: string;
-}
-
-/**
- * @deprecated Use {@link TransfersNftResponse} instead.
- */
-export interface GetMintedNftsResponse {
-  /** An array of the minted NFTs for the provided owner address. */
-  nfts: Nft[];
-
-  /** Key for pagination to use to fetch results from the next page if available. */
   pageKey?: string;
 }
 

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -41,16 +41,11 @@ export enum AlchemyApiType {
  */
 export const EthersNetwork = {
   [Network.ETH_MAINNET]: 'mainnet',
-  [Network.ETH_ROPSTEN]: 'ropsten',
   [Network.ETH_GOERLI]: 'goerli',
-  [Network.ETH_KOVAN]: 'kovan',
-  [Network.ETH_RINKEBY]: 'rinkeby',
   [Network.ETH_SEPOLIA]: 'sepolia',
   [Network.OPT_MAINNET]: 'optimism',
-  [Network.OPT_KOVAN]: 'optimism-kovan',
   [Network.OPT_GOERLI]: 'optimism-goerli',
   [Network.ARB_MAINNET]: 'arbitrum',
-  [Network.ARB_RINKEBY]: 'arbitrum-rinkeby',
   [Network.ARB_GOERLI]: 'arbitrum-goerli',
   [Network.MATIC_MAINNET]: 'matic',
   [Network.MATIC_MUMBAI]: 'maticmum',

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -16,6 +16,8 @@ jest.setTimeout(50000);
 
 // These integration tests check for valid response types and protect against
 // regressions in the backend.
+// TODO(V3): now that types match, add automated tests to check every single field
+// to make sure the schema matches
 describe('E2E integration tests', () => {
   let alchemy: Alchemy;
   const ownerEns = 'vitalik.eth';
@@ -95,9 +97,9 @@ describe('E2E integration tests', () => {
       },
       { contractAddress, tokenId: 13596716 }
     ]);
-    expect(response.length).toEqual(2);
-    expect(response[0].tokenId).toEqual(fromHex('0x8b57f0').toString());
-    expect(response[1].tokenId).toEqual('13596716');
+    expect(response.nfts.length).toEqual(2);
+    expect(response.nfts[0].tokenId).toEqual(fromHex('0x8b57f0').toString());
+    expect(response.nfts[1].tokenId).toEqual('13596716');
   });
 
   it('getContractMetadata()', async () => {
@@ -222,7 +224,7 @@ describe('E2E integration tests', () => {
     expect(response.owners.length).toBeGreaterThan(0);
     expect(response.owners[0].tokenBalances.length).toBeGreaterThan(0);
     expect(typeof response.owners[0].tokenBalances[0].balance).toEqual(
-      'number'
+      'string'
     );
   });
 
@@ -310,15 +312,19 @@ describe('E2E integration tests', () => {
 
   it('getContractMetadataBatch()', async () => {
     const contractAddresses = [
-      '0xe785e82358879f061bc3dcac6f0444462d4b5330',
-      '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d'
+      '0xe785E82358879F061BC3dcAC6f0444462D4b5330',
+      '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D'
     ];
     const response = await alchemy.nft.getContractMetadataBatch(
       contractAddresses
     );
-    expect(response.length).toEqual(2);
-    expect(contractAddresses.includes(response[0].address)).toEqual(true);
-    expect(contractAddresses.includes(response[1].address)).toEqual(true);
+    expect(response.contracts.length).toEqual(2);
+    expect(contractAddresses.includes(response.contracts[0].address)).toEqual(
+      true
+    );
+    expect(contractAddresses.includes(response.contracts[1].address)).toEqual(
+      true
+    );
   });
 
   it('getNftsForOwnerIterator()', async () => {
@@ -399,8 +405,8 @@ describe('E2E integration tests', () => {
 
     // Handles contract address specifying.
     const contractAddresses = [
-      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
-      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
+      '0xa1eB40c284C5B44419425c4202Fa8DabFF31006b',
+      '0x8442864d6AB62a9193be2F16580c08E0D7BCda2f'
     ];
     const response5 = await alchemy.nft.getMintedNfts('vitalik.eth', {
       contractAddresses
@@ -458,8 +464,8 @@ describe('E2E integration tests', () => {
 
     // Handles contract address specifying.
     const contractAddresses = [
-      '0xa1eb40c284c5b44419425c4202fa8dabff31006b',
-      '0x8442864d6ab62a9193be2f16580c08e0d7bcda2f'
+      '0xa1eB40c284C5B44419425c4202Fa8DabFF31006b',
+      '0x8442864d6AB62a9193be2F16580c08E0D7BCda2f'
     ];
     const response5 = await alchemy.nft.getTransfersForOwner(
       'vitalik.eth',
@@ -554,13 +560,13 @@ describe('E2E integration tests', () => {
 
   it('isSpamContract()', async () => {
     const response = await alchemy.nft.isSpamContract(contractAddress);
-    expect(typeof response).toEqual('boolean');
+    expect(typeof response.isSpamContract).toEqual('boolean');
   });
 
   it('getSpamContracts()', async () => {
     const response = await alchemy.nft.getSpamContracts();
-    expect(response.length).toBeGreaterThan(0);
-    expect(typeof response[0]).toEqual('string');
+    expect(response.contractAddresses.length).toBeGreaterThan(0);
+    expect(typeof response.contractAddresses[0]).toEqual('string');
   });
 
   it('getFloorPrice()', async () => {
@@ -630,10 +636,10 @@ describe('E2E integration tests', () => {
     const response = await alchemy.nft.computeRarity(contractAddress, tokenId);
 
     expect(response).toBeDefined();
-    expect(response.length).toBeGreaterThan(0);
-    expect(response[0].prevalence).toBeDefined();
-    expect(response[0].traitType).toBeDefined();
-    expect(response[0].value).toBeDefined();
+    expect(response.rarities.length).toBeGreaterThan(0);
+    expect(response.rarities[0].prevalence).toBeDefined();
+    expect(response.rarities[0].traitType).toBeDefined();
+    expect(response.rarities[0].value).toBeDefined();
   });
 
   it('searchContractMetadata()', async () => {
@@ -642,14 +648,14 @@ describe('E2E integration tests', () => {
     const response = await alchemy.nft.searchContractMetadata(query);
 
     expect(response).toBeDefined();
-    expect(response.length).toBeGreaterThan(0);
-    expect(response[0].address).toBeDefined();
-    expect(typeof response[0].address).toEqual('string');
-    expect(response[0].tokenType).toBeDefined();
+    expect(response.contracts.length).toBeGreaterThan(0);
+    expect(response.contracts[0].address).toBeDefined();
+    expect(typeof response.contracts[0].address).toEqual('string');
+    expect(response.contracts[0].tokenType).toBeDefined();
   });
 
   it('summarizeNftAttributes()', async () => {
-    const contractAddress = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d';
+    const contractAddress = '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D';
 
     const response = await alchemy.nft.summarizeNftAttributes(contractAddress);
 
@@ -657,7 +663,7 @@ describe('E2E integration tests', () => {
     expect(response.contractAddress).toBeDefined();
     expect(response.contractAddress).toEqual(contractAddress);
     expect(response.totalSupply).toBeDefined();
-    expect(typeof response.totalSupply).toEqual('number');
+    expect(typeof response.totalSupply).toEqual('string');
     expect(response.summary).toBeDefined();
   });
 

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,6 +1,5 @@
 import {
   BaseNft,
-  Media,
   Nft,
   NftContract,
   NftSaleMarketplace,
@@ -235,22 +234,6 @@ export function createRawContractForOwner(
     deployedBlockNumber: 42 ?? null,
     ...overrides
   };
-}
-
-export function createNftMediaData(
-  bytes?: number,
-  format?: string,
-  thumbnail?: string
-): Media[] {
-  return [
-    {
-      raw: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
-      gateway: 'http://api.nikeape.xyz/ipfs/nickbanc/1.jpg',
-      bytes,
-      format,
-      thumbnail
-    }
-  ];
 }
 
 export function verifyNftContractMetadata(

--- a/test/unit/alchemy.test.ts
+++ b/test/unit/alchemy.test.ts
@@ -24,7 +24,7 @@ describe('Alchemy class', () => {
   it('preserves settings', () => {
     const config: AlchemySettings = {
       apiKey: 'api-key-here',
-      network: Network.OPT_KOVAN,
+      network: Network.OPT_GOERLI,
       maxRetries: 2,
       url: 'invalid-url'
     };
@@ -35,7 +35,7 @@ describe('Alchemy class', () => {
     config.url = 'another-url';
 
     expect(alchemy.config.apiKey).toEqual('api-key-here');
-    expect(alchemy.config.network).toEqual(Network.OPT_KOVAN);
+    expect(alchemy.config.network).toEqual(Network.OPT_GOERLI);
     expect(alchemy.config.maxRetries).toEqual(2);
     expect(alchemy.config.url).toEqual('invalid-url');
   });
@@ -91,7 +91,7 @@ describe('Alchemy class', () => {
   it('uses the config url instead of apiKey/network if one was provided', () => {
     const alchemy = new Alchemy({
       apiKey: 'api-key-here',
-      network: Network.OPT_KOVAN,
+      network: Network.OPT_GOERLI,
       url: 'custom-url'
     });
     expect(alchemy.config._getRequestUrl(AlchemyApiType.NFT)).toEqual(

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1538,7 +1538,7 @@ describe('NFT module', () => {
       symbol,
       totalSupply
     });
-    const templateResponse = [rawNftContractResponse];
+    const templateResponse = { contracts: [rawNftContractResponse] };
     const expectedNftContract = getNftContractFromRaw(rawNftContractResponse);
 
     beforeEach(() => {


### PR DESCRIPTION
Building on the previous PR in #327, this PR updates the new response types so that all integration tests are passing:

External changes:
- Added `GetNftMetadataBatchResponse`, `GetContractMetadataBatchResponse`, `IsSpamContractResponse`, `GetSpamContractsResponse`, `ComputeRarityResponse`, and `SearchContractMetadataResponse` objects for v3 that replaced primitive or array return types. All methods in v3 should now return an object to allow for future extensibility without breaking changes.
- Renamed `ownerAddresses` to `owners` for `getOwnersForContract()` return object as part of v3
- updated `totalSupply` fields from `number` to `string` to allow for 1155 overflows in v3.

Internal changes:
- Added new `Raw*` types to fully separate backend types from exported types
- Fixed `getTransfers*` methods to properly use the new `GetNftMetadataBatchResponse` type.
- Various test fixes