### PR TITLE
base sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Major Changes
 
+- Add support for Base 
+
 ### Minor Changes
 
 ## 2.9.2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The SDK currently supports the following chains:
 - **Arbitrum**: Mainnet, Goerli, Rinkeby
 - **Astar**: Mainnet
 - **PolygonZKEVM**: Mainnet, Testnet
+- **Base**: Mainnet, Goerli
 
 You can find per-method documentation of the Alchemy SDK endpoints at the [Alchemy Docs linked in the sidebar](https://docs.alchemy.com/reference/alchemy-sdk-quickstart).
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -95,7 +95,9 @@ export enum Network {
   MATIC_MUMBAI = 'polygon-mumbai',
   ASTAR_MAINNET = 'astar-mainnet',
   POLYGONZKEVM_MAINNET = 'polygonzkevm-mainnet',
-  POLYGONZKEVM_TESTNET = 'polygonzkevm-testnet'
+  POLYGONZKEVM_TESTNET = 'polygonzkevm-testnet',
+  BASE_MAINNET = 'base-mainnet',
+  BASE_GOERLI = 'base-goerli'
 }
 
 /** Token Types for the `getTokenBalances()` endpoint. */

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -88,6 +88,14 @@ export const CustomNetworks: { [key: string]: NetworkFromEthers } = {
   'polygonzkevm-testnet': {
     chainId: 1442,
     name: 'polygonzkevm-testnet'
+  },
+  'base-mainnet': {
+    chainId: 8453,
+    name: 'polygonzkevm-mainnet'
+  },
+  'base-goerli': {
+    chainId: 84531,
+    name: 'polygonzkevm-testnet'
   }
 };
 

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -56,7 +56,11 @@ export const EthersNetwork = {
   [Network.MATIC_MUMBAI]: 'maticmum',
   [Network.ASTAR_MAINNET]: 'astar-mainnet',
   [Network.POLYGONZKEVM_MAINNET]: 'polygonzkevm-mainnet',
-  [Network.POLYGONZKEVM_TESTNET]: 'polygonzkevm-testnet'
+  [Network.POLYGONZKEVM_TESTNET]: 'polygonzkevm-testnet',
+  [Network.POLYGONZKEVM_MAINNET]: 'polygonzkevm-mainnet',
+  [Network.POLYGONZKEVM_TESTNET]: 'polygonzkevm-testnet',
+  [Network.BASE_MAINNET]: 'base-mainnet',
+  [Network.BASE_GOERLI]: 'base-goerli'
 };
 
 /**

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -57,8 +57,6 @@ export const EthersNetwork = {
   [Network.ASTAR_MAINNET]: 'astar-mainnet',
   [Network.POLYGONZKEVM_MAINNET]: 'polygonzkevm-mainnet',
   [Network.POLYGONZKEVM_TESTNET]: 'polygonzkevm-testnet',
-  [Network.POLYGONZKEVM_MAINNET]: 'polygonzkevm-mainnet',
-  [Network.POLYGONZKEVM_TESTNET]: 'polygonzkevm-testnet',
   [Network.BASE_MAINNET]: 'base-mainnet',
   [Network.BASE_GOERLI]: 'base-goerli'
 };
@@ -91,11 +89,11 @@ export const CustomNetworks: { [key: string]: NetworkFromEthers } = {
   },
   'base-mainnet': {
     chainId: 8453,
-    name: 'polygonzkevm-mainnet'
+    name: 'base-mainnet'
   },
   'base-goerli': {
     chainId: 84531,
-    name: 'polygonzkevm-testnet'
+    name: 'base-goerli'
   }
 };
 


### PR DESCRIPTION
Base is an OP Stack chain and supports all the same deps as optimism chains. Its supported in ethers as well per their docs, however the tests didn't seem to pass when I didn't blacklist it. Alchemy has support for all core rpc methods at time of writing listed here: https://alchemyinsights.slack.com/archives/CD5H0MAFM/p1691717149204729

w/ some followup timelines for enhanced features seen here: https://www.notion.so/alchemotion/Internal-Only-Base-GTM-Run-of-Show-605f8a5e945f477796d94ad46bd4b884