### PR TITLE
Include 'removed' field in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 ### Minor Changes
 
+- Fixed a bug in the `Log` object where the `removed` field was not included in the response.
+
 ## 2.10.0
 
 ### Major Changes
 
-- Add support for Base 
+- Add support for Base
 
 ### Minor Changes
 

--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -319,6 +319,16 @@ export class AlchemyProvider
     return result;
   }
 
+  /**
+   * Overrides the base `Formatter` class inherited from ethers to support
+   * returning custom fields in Ethers response types.
+   *
+   * For context, ethers has a `Formatter` class that is used to format the
+   * response from a JSON-RPC request. Any fields that are not defined in the
+   * `Formatter` class are removed from the returned response. By modifying the
+   * `Formatter` class in this method, we can add support for fields that are
+   * not defined in ethers.
+   */
   private modifyFormatter(): void {
     this.formatter.formats['receiptLog']['removed'] = val => {
       if (typeof val === 'boolean') {

--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -93,6 +93,8 @@ export class AlchemyProvider
       return fetchJson(batcherConnection, JSON.stringify(requests));
     };
     this.batcher = new RequestBatcher(sendBatchFn);
+
+    this.modifyFormatter();
   }
 
   /**
@@ -315,6 +317,15 @@ export class AlchemyProvider
     }
 
     return result;
+  }
+
+  private modifyFormatter(): void {
+    this.formatter.formats['receiptLog']['removed'] = val => {
+      if (typeof val === 'boolean') {
+        return val;
+      }
+      return undefined;
+    };
   }
 }
 

--- a/test/unit/core-namespace.test.ts
+++ b/test/unit/core-namespace.test.ts
@@ -1,4 +1,4 @@
-import { Alchemy } from '../../src';
+import { Alchemy, Network } from '../../src';
 
 describe('Core Namespace', () => {
   let alchemy: Alchemy;
@@ -13,5 +13,13 @@ describe('Core Namespace', () => {
         alchemy.core.getTokenBalances(address, [])
       ).rejects.toThrow();
     });
+  });
+
+  it('test', async () => {
+    alchemy = new Alchemy({ network: Network.MATIC_MUMBAI });
+    const a = await alchemy.core.getTransactionReceipt(
+      '0xf5f8aa62d97024d3566ecfeb7fd696f621182608dde8b0eee45fa351d2a00ba7'
+    );
+    console.log(a);
   });
 });

--- a/test/unit/core-namespace.test.ts
+++ b/test/unit/core-namespace.test.ts
@@ -1,4 +1,4 @@
-import { Alchemy, Network } from '../../src';
+import { Alchemy } from '../../src';
 
 describe('Core Namespace', () => {
   let alchemy: Alchemy;
@@ -13,13 +13,5 @@ describe('Core Namespace', () => {
         alchemy.core.getTokenBalances(address, [])
       ).rejects.toThrow();
     });
-  });
-
-  it('test', async () => {
-    alchemy = new Alchemy({ network: Network.MATIC_MUMBAI });
-    const a = await alchemy.core.getTransactionReceipt(
-      '0xf5f8aa62d97024d3566ecfeb7fd696f621182608dde8b0eee45fa351d2a00ba7'
-    );
-    console.log(a);
   });
 });


### PR DESCRIPTION
This PR adds support for the `removed` boolean field in the `Log` class (returned by `core.getLogs()` and `core.getTransactionReceipt()`).

The core ethers library does not recognize this field and prunes it from the response. By adding a validator function onto the formatter in the base `AlchemyProvider` class, we're able to add custom fields.