### PR TITLE
[DO NOT MERGE] Update SDK to use new slug and floorPrice

### DIFF
--- a/src/api/nft.ts
+++ b/src/api/nft.ts
@@ -3,7 +3,6 @@ import {
   NftImage,
   NftSpamClassification,
   NftTokenType,
-  OpenSeaBaseCollectionMetadata,
   OpenSeaCollectionMetadata
 } from '../types/types';
 
@@ -55,9 +54,9 @@ export interface NftCollection {
   /** The name of the collection. */
   name: string;
   /** The OpenSea human-readable slug of the collection. */
-  openSeaSlug?: string;
-  /** OpenSea-specific collection metadata such as floor price. */
-  openSea?: OpenSeaBaseCollectionMetadata;
+  slug?: string;
+  /** The floor price of the collection*/
+  floorPrice?: NftCollectionFloorPrice;
   /** The description of the collection. */
   description?: string;
   /** The homepage of the collection as determined by OpenSea. */
@@ -66,6 +65,26 @@ export interface NftCollection {
   twitterUsername?: string;
   /** The Discord URL of the collection. */
   discordUrl?: string;
+}
+
+/**
+ * Floor price object for an NFT collection.
+ */
+export interface NftCollectionFloorPrice {
+  /** The marketplace where the floor price was determined. */
+  marketplace?: NftCollectionMarketplace;
+  /** The floor price of the collection. */
+  floorPrice?: number;
+  /** The currency of the floor price. */
+  priceCurrency?: string;
+}
+
+/**
+ * Enum representing the supported NFT marketplaces on a
+ * {@link NftCollectionFloorPrice} object.
+ */
+export enum NftCollectionMarketplace {
+  OPENSEA = 'OpenSea'
 }
 
 /**

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -67,22 +67,23 @@ export interface RawNftContractForNft extends RawNftContract {
  */
 export interface RawNftCollection {
   name: string;
-  openSeaSlug: string | null;
-  openSea: RawOpenSeaBaseCollectionMetadata | null;
+  slug: string | null;
+  floorPrice: RawNftCollectionFloorPrice;
   description: string | null;
   externalUrl: string | null;
   twitterUsername: string | null;
   discordUrl: string | null;
 }
 
-/** OpenSea's base metadata for an NFT collection */
-export interface RawOpenSeaBaseCollectionMetadata {
-  floorPrice?: number;
+export interface RawNftCollectionFloorPrice {
+  marketplace: string | null;
+  floorPrice: number | null;
+  priceCurrency: string | null;
 }
 
 /** OpenSea's full metadata for an NFT collection. */
-export interface RawOpenSeaCollectionMetadata
-  extends RawOpenSeaBaseCollectionMetadata {
+export interface RawOpenSeaCollectionMetadata {
+  floorPrice: number | null;
   collectionName: string | null;
   safelistRequestStatus: string | null;
   imageUrl: string | null;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1654,15 +1654,10 @@ export interface NftContractNftsResponse {
   pageKey?: string;
 }
 
-/** OpenSea's base metadata for an NFT collection. */
-export interface OpenSeaBaseCollectionMetadata {
-  /** The floor price of the NFT. */
-  floorPrice?: number;
-}
-
 /** OpenSea's metadata for an NFT collection. */
-export interface OpenSeaCollectionMetadata
-  extends OpenSeaBaseCollectionMetadata {
+export interface OpenSeaCollectionMetadata {
+  /** The floor price of the collection. */
+  floorPrice?: number;
   /** The name of the collection on OpenSea. */
   collectionName?: string;
   /** The approval status of the collection on OpenSea. */

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -2,6 +2,7 @@ import {
   BaseNft,
   Nft,
   NftCollection,
+  NftCollectionMarketplace,
   NftContract,
   NftContractForNft
 } from '../api/nft';
@@ -88,7 +89,15 @@ export function getNftContractFromRaw(
 export function getNftCollectionFromRaw(
   rawNftCollection: RawNftCollection
 ): NftCollection {
-  return nullsToUndefined<NftCollection>(rawNftCollection);
+  return nullsToUndefined<NftCollection>({
+    ...rawNftCollection,
+    floorPrice: {
+      ...rawNftCollection.floorPrice,
+      marketplace: parseNftCollectionMarketplace(
+        rawNftCollection.floorPrice.marketplace
+      )
+    }
+  });
 }
 
 export function getBaseNftFromRaw(rawBaseNft: RawOwnedBaseNft): BaseNft;
@@ -147,6 +156,17 @@ function parseNftSaleMarketplace(marketplace: string): NftSaleMarketplace {
       return NftSaleMarketplace.BLUR;
     default:
       return NftSaleMarketplace.UNKNOWN;
+  }
+}
+
+function parseNftCollectionMarketplace(
+  marketplace: string | null
+): NftCollectionMarketplace | undefined {
+  switch (marketplace) {
+    case 'OpenSea':
+      return NftCollectionMarketplace.OPENSEA;
+    default:
+      return undefined;
   }
 }
 

--- a/test/integration/nft.test.ts
+++ b/test/integration/nft.test.ts
@@ -55,8 +55,8 @@ describe('E2E integration tests', () => {
 
   function verifyNftCollectionMetadata(metadata: NftCollection): void {
     expect(typeof metadata.name).toEqual('string');
-    expect(typeof metadata.openSeaSlug).toEqual('string');
-    expect(metadata.openSea).toBeDefined();
+    expect(typeof metadata.slug).toEqual('string');
+    expect(metadata.floorPrice).toBeDefined();
     expect(typeof metadata.description).toEqual('string');
     expect(typeof metadata.externalUrl).toEqual('string');
     expect(typeof metadata.twitterUsername).toEqual('string');


### PR DESCRIPTION
Change v3 types to use updated `slug` and `floorPrice` objects. Merge after backend change is complete