### PR TITLE
Fix: Update OpenSeaCollectionMetadata and RawOpenSeaCollectionMetadata Type Definitions

### DIFF
--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -122,8 +122,10 @@ export interface RawBaseNftCollection {
 export interface RawOpenSeaCollectionMetadata {
   floorPrice: number | null;
   collectionName: string | null;
+  collectionSlug: string | null;
   safelistRequestStatus: string | null;
   imageUrl: string | null;
+  bannerImageUrl: string | null;
   description: string | null;
   externalUrl: string | null;
   twitterUsername: string | null;

--- a/src/types/nft-types.ts
+++ b/src/types/nft-types.ts
@@ -1113,10 +1113,14 @@ export interface OpenSeaCollectionMetadata {
   floorPrice?: number;
   /** The name of the collection on OpenSea. */
   collectionName?: string;
+  /** The slug of the collection on OpenSea. */
+  collectionSlug?: string;
   /** The approval status of the collection on OpenSea. */
   safelistRequestStatus?: OpenSeaSafelistRequestStatus;
   /** The image URL determined by OpenSea. */
   imageUrl?: string;
+  /** The banner image URL determined by OpenSea. */
+  imageBannerUrl?: string;
   /** The description of the collection on OpenSea. */
   description?: string;
   /** The homepage of the collection as determined by OpenSea. */

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -32,8 +32,10 @@ export function createRawOpenSeaCollectionMetadata(): RawOpenSeaCollectionMetada
   return {
     floorPrice: 2.2998,
     collectionName: 'Collection Name',
+    collectionSlug: 'collectionname',
     safelistRequestStatus: 'verified',
     imageUrl: 'http://image.url',
+    bannerImageUrl: 'http://banner.url',
     description: 'A sample description',
     externalUrl: 'http://external.url',
     twitterUsername: 'twitter-handle',

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1137,8 +1137,10 @@ describe('NFT module', () => {
     const expectedOpenseaMetadata = {
       floorPrice: 2.2998,
       collectionName: 'Collection Name',
+      collectionSlug: 'collectionname',
       safelistRequestStatus: OpenSeaSafelistRequestStatus.VERIFIED,
       imageUrl: 'http://image.url',
+      bannerImageUrl: 'http://banner.url',
       description: 'A sample description',
       externalUrl: 'http://external.url',
       twitterUsername: 'twitter-handle',


### PR DESCRIPTION
**Context**:
This PR addresses the missing fields `bannerImageUrl` and `collectionSlug` in the type definitions, as highlighted in issue #384.

**Changes**:
1. Updated the `OpenSeaCollectionMetadata` type definition to include `bannerImageUrl` and `collectionSlug`.
2. During testing, observed that the `collectionSlug` field was also returned but wasn't in the type definition.
3. Reviewed the API and inferred that the `RawOpenSeaCollectionMetadata` might have the same oversight. The README mentioned potential discrepancies between the SDK and API, prompting further verification.
4. Validated the presence of `bannerImageUrl` and `collectionSlug` fields in the nft API endpoint: `https://eth-mainnet.g.alchemy.com/nft/v2/{{apiKey}}/getContractMetadata?contractAddress=0x60e4d786628fea6478f785a6d7e704777c86a7c6`.
5. Consequently, updated the `RawOpenSeaCollectionMetadata` type definition and made necessary adjustments to mock and expected values for the API unit test.

**Testing**:
- Ensured the test file `unit/nft-api.test.ts` passed without issues.
- Ensured the test file `integration/nft.test.ts` passed with out new issues (there was one failing test before I made my edits `getOwnersForContract() with includeCount`)

**Conclusion**:
With the types updated and tests passing, this PR is prepared to address the discrepancies mentioned in issue #384.
