### PR TITLE
fix(types): Add missing fields to openSeaMetadata type

### DIFF
--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -122,8 +122,10 @@ export interface RawBaseNftCollection {
 export interface RawOpenSeaCollectionMetadata {
   floorPrice: number | null;
   collectionName: string | null;
+  collectionSlug: string | null;
   safelistRequestStatus: string | null;
   imageUrl: string | null;
+  bannerImageUrl: string | null;
   description: string | null;
   externalUrl: string | null;
   twitterUsername: string | null;

--- a/src/types/nft-types.ts
+++ b/src/types/nft-types.ts
@@ -1113,10 +1113,14 @@ export interface OpenSeaCollectionMetadata {
   floorPrice?: number;
   /** The name of the collection on OpenSea. */
   collectionName?: string;
+  /** The slug of the collection on OpenSea. */
+  collectionSlug?: string;
   /** The approval status of the collection on OpenSea. */
   safelistRequestStatus?: OpenSeaSafelistRequestStatus;
   /** The image URL determined by OpenSea. */
   imageUrl?: string;
+  /** The banner image URL determined by OpenSea. */
+  imageBannerUrl?: string;
   /** The description of the collection on OpenSea. */
   description?: string;
   /** The homepage of the collection as determined by OpenSea. */

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -32,8 +32,10 @@ export function createRawOpenSeaCollectionMetadata(): RawOpenSeaCollectionMetada
   return {
     floorPrice: 2.2998,
     collectionName: 'Collection Name',
+    collectionSlug: 'collectionname',
     safelistRequestStatus: 'verified',
     imageUrl: 'http://image.url',
+    bannerImageUrl: 'http://banner.url',
     description: 'A sample description',
     externalUrl: 'http://external.url',
     twitterUsername: 'twitter-handle',

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1137,8 +1137,10 @@ describe('NFT module', () => {
     const expectedOpenseaMetadata = {
       floorPrice: 2.2998,
       collectionName: 'Collection Name',
+      collectionSlug: 'collectionname',
       safelistRequestStatus: OpenSeaSafelistRequestStatus.VERIFIED,
       imageUrl: 'http://image.url',
+      bannerImageUrl: 'http://banner.url',
       description: 'A sample description',
       externalUrl: 'http://external.url',
       twitterUsername: 'twitter-handle',


### PR DESCRIPTION
This commit resolves a type issue where users could not reference 'bannerImageUrl' and 'collectionSlug' without encountering type errors. Updates have been made to both the SDK and API for version 3.0.0-beta.3.

Resolves: #384