### PR TITLE
Fix incorrect fields in NftNamespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Major Changes
 
+### Minor Changes
+
+- Added a missing `marketplaceAddress` field to the `NftSale` in `NftNamespace.getNftSales()`.
+- Fixed an incorrect field name for `bannerImageUrl` in `OpenSeaCollectionMetadata`. Deprecated the old field name `imageBannerUrl`.
+
 ## 3.1.0
 
 ### Major Changes

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -327,6 +327,7 @@ export interface RawGetNftSalesResponse {
 
 export interface RawNftSale {
   marketplace: string;
+  marketplaceAddress: string;
   contractAddress: string;
   tokenId: string;
   quantity: string;

--- a/src/types/nft-types.ts
+++ b/src/types/nft-types.ts
@@ -724,6 +724,9 @@ export interface NftSale {
   /** The marketplace the sale took place on. */
   marketplace: NftSaleMarketplace;
 
+  /** The marketplace address the sale was on. */
+  marketplaceAddress: string;
+
   /** The NFT contract address. */
   contractAddress: string;
 
@@ -1119,8 +1122,13 @@ export interface OpenSeaCollectionMetadata {
   safelistRequestStatus?: OpenSeaSafelistRequestStatus;
   /** The image URL determined by OpenSea. */
   imageUrl?: string;
-  /** The banner image URL determined by OpenSea. */
+  /**
+   * The banner image URL determined by OpenSea.
+   * @deprecated Use {@link bannerImageUrl} instead.
+   */
   imageBannerUrl?: string;
+  /** The banner image URL determined by OpenSea. */
+  bannerImageUrl?: string;
   /** The description of the collection on OpenSea. */
   description?: string;
   /** The homepage of the collection as determined by OpenSea. */

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -177,6 +177,7 @@ export function createOwnedNft(
 }
 
 export function createRawNftSale(
+  marketplaceAddress: string,
   contractAddress: string,
   tokenId: string,
   marketplace: NftSaleMarketplace,
@@ -195,6 +196,7 @@ export function createRawNftSale(
     blockNumber: 15948091,
     bundleIndex: 0,
     buyerAddress,
+    marketplaceAddress,
     contractAddress,
     logIndex: 392,
     marketplace,

--- a/test/unit/nft-api.test.ts
+++ b/test/unit/nft-api.test.ts
@@ -1399,12 +1399,14 @@ describe('NFT module', () => {
 
   describe('getNftSales', () => {
     const contractAddress = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d';
+    const marketplaceAddress = '0x000440f08436a7b866d1ae42db5e0be801da722a';
     const tokenId = '42';
     const buyerAddress = '0xa56c6b57127e8881fbe51046058d0ddc1bb9e24f';
     const sellerAddress = '0xb60653cc0acff21cdf59e57bcd5de99e305a4c1c';
     const templateResponse: RawGetNftSalesResponse = {
       nftSales: [
         createRawNftSale(
+          marketplaceAddress,
           contractAddress,
           tokenId,
           NftSaleMarketplace.LOOKSRARE,
@@ -1413,6 +1415,7 @@ describe('NFT module', () => {
           sellerAddress
         ),
         createRawNftSale(
+          marketplaceAddress,
           contractAddress,
           tokenId,
           NftSaleMarketplace.SEAPORT,
@@ -1421,6 +1424,7 @@ describe('NFT module', () => {
           sellerAddress
         ),
         createRawNftSale(
+          marketplaceAddress,
           contractAddress,
           tokenId,
           NftSaleMarketplace.X2Y2,


### PR DESCRIPTION
- Added a missing `marketplaceAddress` field to the `NftSale` in `NftNamespace.getNftSales()`.
- Fixed an incorrect field name for `bannerImageUrl` in `OpenSeaCollectionMetadata`.
