### PR TITLE
Add support for overriding Ethers ConnectionInfo

### DIFF
--- a/src/api/alchemy-config.ts
+++ b/src/api/alchemy-config.ts
@@ -1,3 +1,5 @@
+import { ConnectionInfo } from '@ethersproject/web';
+
 import { AlchemySettings, Network } from '../types/types';
 import {
   AlchemyApiType,
@@ -30,6 +32,8 @@ export class AlchemyConfig {
 
   /** Setting to enable automatic batching on json-rpc requests. Defaults to false.*/
   readonly batchRequests: boolean;
+
+  readonly connectionInfoOverrides?: Partial<ConnectionInfo>;
 
   /**
    * The optional hardcoded URL to send requests to instead of using the network
@@ -69,6 +73,7 @@ export class AlchemyConfig {
     this.authToken = config?.authToken;
     this.batchRequests = config?.batchRequests || false;
     this.requestTimeout = config?.requestTimeout || DEFAULT_REQUEST_TIMEOUT;
+    this.connectionInfoOverrides = config?.connectionInfoOverrides;
   }
 
   /**

--- a/src/api/alchemy-provider.ts
+++ b/src/api/alchemy-provider.ts
@@ -55,7 +55,7 @@ export class AlchemyProvider
 
     // Generate our own connection info with the correct endpoint URLs.
     const alchemyNetwork = AlchemyProvider.getAlchemyNetwork(config.network);
-    const connection = AlchemyProvider.getAlchemyConnectionInfo(
+    let connection = AlchemyProvider.getAlchemyConnectionInfo(
       alchemyNetwork,
       apiKey,
       'http'
@@ -68,6 +68,14 @@ export class AlchemyProvider
     }
 
     connection.throttleLimit = config.maxRetries;
+
+    // Add user provided overrides if they exist.
+    if (config.connectionInfoOverrides) {
+      connection = {
+        ...connection,
+        ...config.connectionInfoOverrides
+      };
+    }
 
     // Normalize the Alchemy named network input to the network names used by
     // ethers. This allows the parent super constructor in JsonRpcProvider to

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,7 @@ import {
   TransactionReceipt
 } from '@ethersproject/abstract-provider';
 import { BigNumberish } from '@ethersproject/bignumber';
+import { ConnectionInfo } from '@ethersproject/web';
 
 import {
   ERC1155Metadata,
@@ -68,6 +69,22 @@ export interface AlchemySettings {
    * This implementation is based on the `JsonRpcBatchProvider` in ethers.
    */
   batchRequests?: boolean;
+
+  /**
+   * Optional overrides on the Ethers `ConnectionInfo` object used to configure
+   * the underlying JsonRpcProvider. This field is for advanced users who want
+   * to customize the provider's behavior.
+   *
+   * This override is applied last, so it will override any other
+   * AlchemySettings properties that affect the connection.
+   *
+   * Note that modifying the ConnectionInfo may break Alchemy SDK's default
+   * connection/url logic. It also does not affect `nft` and `notify`
+   * namespaces.
+   *
+   * {@link https://docs.ethers.org/v5/api/utils/web/#ConnectionInfo}
+   */
+  connectionInfoOverrides?: Partial<ConnectionInfo>;
 }
 
 /**


### PR DESCRIPTION
Should help workaround #400.

This PR adds support for providing a `ConnectionInfo` object to override the default ethers.js `ConnectionInfo` used in `JsonRpcProvider`.