### PR TITLE
fix: SafelistRequestStatus undefined fix

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -74,7 +74,7 @@ export function getNftContractFromRaw(
     openSeaMetadata: {
       ...rawNftContract.openSeaMetadata,
       safelistRequestStatus:
-        rawNftContract.openSeaMetadata?.safelistRequestStatus !== null
+        rawNftContract.openSeaMetadata?.safelistRequestStatus
           ? stringToEnum(
               rawNftContract.openSeaMetadata.safelistRequestStatus,
               OpenSeaSafelistRequestStatus


### PR DESCRIPTION
@thebrianchen The previous fix handled the undefined value but the comparison was wrong.

`rawNftContract.openSeaMetadata?.safelistRequestStatus !== null` will return 'true' if the value is undefined.