### PR TITLE
Fix GraphQL webhook creation and support skip_empty_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Minor Changes
 
+- Fixed a bug with `NotifyNamespace.createWebhook()` when using `WebhookType.GRAPHQL`. Also added the option use `skipEmptyMessages` when creating graphQL webhooks to skip empty blocks.
+
 ## 3.3.1
 
 ### Minor Changes

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1202,6 +1202,25 @@ export interface CustomGraphqlWebhookParams {
    * created on network of the app provided in the api key config.
    */
   network?: Network;
+  /**
+   * Whether to only receive webhooks if the query on the block is not empty.
+   * Defaults to false.
+   */
+  skipEmptyMessages?: boolean;
+  /**
+   * App IDs are now required for graphQL webhooks. You can find the app ID
+   * following the steps here:
+   * {@link https://docs.alchemy.com/reference/notify-api-faq#where-can-i-find-the-app-id}.
+   *
+   * The webhook will be created on the app and network associated with the appId.
+   * To find the app id of a project, go to the Alchemy Dashboard in the Apps tab.
+   * After clicking on an app, the app id is the string in the URL following 'apps/'.
+   *
+   * Note that although this property is marked as optional, it is *actually required*
+   * for creating a custom GraphQL webhook. This is a workaround to avoid a breaking
+   * change in the API.
+   */
+  appId?: string;
 }
 
 /**

--- a/test/integration/notify.test.ts
+++ b/test/integration/notify.test.ts
@@ -57,7 +57,12 @@ describe('E2E integration tests', () => {
     customWh = await alchemy.notify.createWebhook(
       webhookUrl,
       WebhookType.GRAPHQL,
-      { graphqlQuery, network: Network.ETH_MAINNET }
+      {
+        graphqlQuery,
+        network: Network.ETH_MAINNET,
+        appId,
+        skipEmptyMessages: true
+      }
     );
   }
 
@@ -247,11 +252,16 @@ describe('E2E integration tests', () => {
     const customWebhook = await alchemy.notify.createWebhook(
       webhookUrl,
       WebhookType.GRAPHQL,
-      { graphqlQuery, network: Network.ETH_GOERLI }
+      {
+        graphqlQuery,
+        network: Network.ETH_MAINNET,
+        appId,
+        skipEmptyMessages: true
+      }
     );
     expect(customWebhook.url).toEqual(webhookUrl);
     expect(customWebhook.type).toEqual(WebhookType.GRAPHQL);
-    expect(customWebhook.network).toEqual(Network.ETH_GOERLI);
+    expect(customWebhook.network).toEqual(Network.ETH_MAINNET);
     let response = await alchemy.notify.getAllWebhooks();
     expect(
       response.webhooks.filter(wh => wh.id === customWebhook.id).length


### PR DESCRIPTION
Fixing a bug where creating graphQL webhooks returned 503s. This was caused by a new requirement to include app ID with the creation request.

Also added support for the `skip_empty_messages` param, which skips sending webhooks for requests that come from empty blocks