### PR TITLE
feat: add PricesNamespace and related methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Major Changes
 
+- Added a new `PricesNamespace` with three new methods: `getTokenPriceByAddress()`, `getTokenPriceBySymbol()`, `getHistoricalPriceByAddress`, and `getHistoricalPriceBySymbol()`. Access these methods via `alchemy.prices`.
+
 ### Minor Changes
 
 ## 3.4.8

--- a/src/api/alchemy-config.ts
+++ b/src/api/alchemy-config.ts
@@ -9,7 +9,8 @@ import {
   DEFAULT_REQUEST_TIMEOUT,
   getAlchemyHttpUrl,
   getAlchemyNftHttpUrl,
-  getAlchemyWebhookHttpUrl
+  getAlchemyWebhookHttpUrl,
+  getPricesBaseUrl
 } from '../util/const';
 import type { AlchemyProvider } from './alchemy-provider';
 import type { AlchemyWebSocketProvider } from './alchemy-websocket-provider';
@@ -91,6 +92,8 @@ export class AlchemyConfig {
       return getAlchemyNftHttpUrl(this.network, this.apiKey);
     } else if (apiType === AlchemyApiType.WEBHOOK) {
       return getAlchemyWebhookHttpUrl();
+    } else if (apiType === AlchemyApiType.PRICES) {
+      return getPricesBaseUrl(this.apiKey);
     } else {
       return getAlchemyHttpUrl(this.network, this.apiKey);
     }

--- a/src/api/alchemy.ts
+++ b/src/api/alchemy.ts
@@ -4,6 +4,7 @@ import { CoreNamespace } from './core-namespace';
 import { DebugNamespace } from './debug-namespace';
 import { NftNamespace } from './nft-namespace';
 import { NotifyNamespace } from './notify-namespace';
+import { PricesNamespace } from './prices-namespace';
 import { TransactNamespace } from './transact-namespace';
 import { WebSocketNamespace } from './websocket-namespace';
 
@@ -53,6 +54,9 @@ export class Alchemy {
    */
   readonly debug: DebugNamespace;
 
+  /** The `prices` namespace contains methods for getting token price data. */
+  readonly prices: PricesNamespace;
+
   /**
    * @param {string} [settings.apiKey] - The API key to use for Alchemy
    * @param {Network} [settings.network] - The network to use for Alchemy
@@ -69,5 +73,6 @@ export class Alchemy {
     this.transact = new TransactNamespace(this.config);
     this.notify = new NotifyNamespace(this.config);
     this.debug = new DebugNamespace(this.config);
+    this.prices = new PricesNamespace(this.config);
   }
 }

--- a/src/api/prices-namespace.ts
+++ b/src/api/prices-namespace.ts
@@ -1,0 +1,107 @@
+import {
+  getHistoricalPriceByAddress,
+  getHistoricalPriceBySymbol,
+  getTokenPriceByAddress,
+  getTokenPriceBySymbol
+} from '../internal/prices-api';
+import {
+  GetTokenPriceByAddressResponse,
+  GetTokenPriceBySymbolResponse,
+  HistoricalPriceByAddressResponse,
+  HistoricalPriceBySymbolResponse,
+  HistoricalPriceInterval,
+  TokenAddressRequest
+} from '../types/prices-types';
+import { Network } from '../types/types';
+import { AlchemyConfig } from './alchemy-config';
+
+/**
+ * The Prices namespace contains methods for getting token price data.
+ *
+ * Do not call this constructor directly. Instead, instantiate an Alchemy object
+ * with `const alchemy = new Alchemy(config)` and then access the prices namespace
+ * via `alchemy.prices`.
+ */
+export class PricesNamespace {
+  /** @internal */
+  constructor(private readonly config: AlchemyConfig) {}
+
+  /**
+   * Get token prices by network and contract address pairs.
+   *
+   * @param addresses - Array of network/address pairs to get prices for
+   * @returns Promise containing token price data
+   * @public
+   */
+  getTokenPriceByAddress(
+    addresses: TokenAddressRequest[]
+  ): Promise<GetTokenPriceByAddressResponse> {
+    return getTokenPriceByAddress(this.config, addresses);
+  }
+
+  /**
+   * Get token prices by token symbol.
+   *
+   * @param symbols - Array of token symbols to get prices for
+   * @returns Promise containing token price data
+   * @public
+   */
+  getTokenPriceBySymbol(
+    symbols: string[]
+  ): Promise<GetTokenPriceBySymbolResponse> {
+    return getTokenPriceBySymbol(this.config, symbols);
+  }
+
+  /**
+   * Get historical token prices by token symbol.
+   *
+   * @param symbol - The token symbol to get historical prices for
+   * @param startTime - Start time in ISO-8601 string format or Unix timestamp in seconds
+   * @param endTime - End time in ISO-8601 string format or Unix timestamp in seconds
+   * @param interval - Time interval between data points
+   * @returns Promise containing historical token price data
+   * @public
+   */
+  getHistoricalPriceBySymbol(
+    symbol: string,
+    startTime: string | number,
+    endTime: string | number,
+    interval: HistoricalPriceInterval
+  ): Promise<HistoricalPriceBySymbolResponse> {
+    return getHistoricalPriceBySymbol(
+      this.config,
+      symbol,
+      startTime,
+      endTime,
+      interval
+    );
+  }
+
+  /**
+   * Get historical token prices by network and contract address.
+   *
+   * @param network - The network where the token contract is deployed
+   * @param address - The token contract address
+   * @param startTime - Start time in ISO-8601 string format or Unix timestamp in seconds
+   * @param endTime - End time in ISO-8601 string format or Unix timestamp in seconds
+   * @param interval - Time interval between data points
+   * @returns Promise containing historical token price data
+   * @public
+   */
+  getHistoricalPriceByAddress(
+    network: Network,
+    address: string,
+    startTime: string | number,
+    endTime: string | number,
+    interval: HistoricalPriceInterval
+  ): Promise<HistoricalPriceByAddressResponse> {
+    return getHistoricalPriceByAddress(
+      this.config,
+      network,
+      address,
+      startTime,
+      endTime,
+      interval
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export * from './types/types';
 
 export * from './types/nft-types';
 
+export * from './types/prices-types';
+
 export { Alchemy } from './api/alchemy';
 
 export { Wallet } from './api/alchemy-wallet';
@@ -38,6 +40,8 @@ export type { TransactNamespace } from './api/transact-namespace';
 export type { NotifyNamespace } from './api/notify-namespace';
 
 export type { DebugNamespace } from './api/debug-namespace';
+
+export type { PricesNamespace } from './api/prices-namespace';
 
 export { fromHex, toHex, isHex } from './api/util';
 

--- a/src/internal/prices-api.ts
+++ b/src/internal/prices-api.ts
@@ -1,0 +1,138 @@
+import { AlchemyConfig } from '../api/alchemy-config';
+import {
+  GetTokenPriceByAddressResponse,
+  GetTokenPriceBySymbolRequest,
+  GetTokenPriceBySymbolResponse,
+  HistoricalPriceByAddressResponse,
+  HistoricalPriceBySymbolResponse,
+  HistoricalPriceInterval,
+  TokenAddressRequest
+} from '../types/prices-types';
+import { Network } from '../types/types';
+import { AlchemyApiType } from '../util/const';
+import { nullsToUndefined } from '../util/util';
+import { requestHttpWithBackoff } from './dispatch';
+
+const PRICES_BASE_URL = 'https://api.g.alchemy.com/prices/v1/alch-demo';
+
+export async function getTokenPriceByAddress(
+  config: AlchemyConfig,
+  addresses: TokenAddressRequest[],
+  srcMethod = 'getTokenPriceByAddress'
+): Promise<GetTokenPriceByAddressResponse> {
+  const response = await requestHttpWithBackoff<
+    {},
+    GetTokenPriceByAddressResponse
+  >(
+    config,
+    AlchemyApiType.PRICES,
+    'tokens/by-address',
+    srcMethod,
+    {},
+    {
+      method: 'POST',
+      data: { addresses },
+      baseURL: PRICES_BASE_URL
+    }
+  );
+  return nullsToUndefined<GetTokenPriceByAddressResponse>(response);
+}
+
+export async function getTokenPriceBySymbol(
+  config: AlchemyConfig,
+  symbols: string[],
+  srcMethod = 'getTokenPriceBySymbol'
+): Promise<GetTokenPriceBySymbolResponse> {
+  const response = await requestHttpWithBackoff<
+    GetTokenPriceBySymbolRequest,
+    GetTokenPriceBySymbolResponse
+  >(
+    config,
+    AlchemyApiType.PRICES,
+    'tokens/by-symbol',
+    srcMethod,
+    {
+      symbols
+    },
+    {
+      // We need to serialize the symbols array as URLSearchParams since the
+      // Alchemy API expects a query parameter for each symbol. The axios default
+      // serializer will not work here because the symbols array is an array of
+      // strings.
+      // Axios default encoding: ?symbols[]=AAVE&symbols[]=UNI
+      // Alchemy requires: ?symbols=AAVE&symbols=UNI
+      paramsSerializer: params => {
+        const searchParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+          value.forEach((v: string) => searchParams.append(key, v));
+        });
+        return searchParams.toString();
+      }
+    }
+  );
+  return nullsToUndefined<GetTokenPriceBySymbolResponse>(response);
+}
+
+export async function getHistoricalPriceBySymbol(
+  config: AlchemyConfig,
+  symbol: string,
+  startTime: string | number,
+  endTime: string | number,
+  interval: HistoricalPriceInterval,
+  srcMethod = 'getHistoricalPriceBySymbol'
+): Promise<HistoricalPriceBySymbolResponse> {
+  const response = await requestHttpWithBackoff<
+    {},
+    HistoricalPriceBySymbolResponse
+  >(
+    config,
+    AlchemyApiType.PRICES,
+    'tokens/historical',
+    srcMethod,
+    {},
+    {
+      method: 'POST',
+      data: {
+        symbol,
+        startTime,
+        endTime,
+        interval
+      },
+      baseURL: PRICES_BASE_URL
+    }
+  );
+  return nullsToUndefined<HistoricalPriceBySymbolResponse>(response);
+}
+
+export async function getHistoricalPriceByAddress(
+  config: AlchemyConfig,
+  network: Network,
+  address: string,
+  startTime: string | number,
+  endTime: string | number,
+  interval: HistoricalPriceInterval,
+  srcMethod = 'getHistoricalPriceByAddress'
+): Promise<HistoricalPriceByAddressResponse> {
+  const response = await requestHttpWithBackoff<
+    {},
+    HistoricalPriceByAddressResponse
+  >(
+    config,
+    AlchemyApiType.PRICES,
+    'tokens/historical',
+    srcMethod,
+    {},
+    {
+      method: 'POST',
+      data: {
+        network,
+        address,
+        startTime,
+        endTime,
+        interval
+      },
+      baseURL: PRICES_BASE_URL
+    }
+  );
+  return nullsToUndefined<HistoricalPriceByAddressResponse>(response);
+}

--- a/src/types/prices-types.ts
+++ b/src/types/prices-types.ts
@@ -1,0 +1,174 @@
+import { Network } from './types';
+
+/**
+ * The parameter field of {@link PricesNamespace.getTokenPriceByAddress}.
+ * Represents a network and address pair for getting token prices.
+ *
+ * @public
+ */
+export interface TokenAddressRequest {
+  /** The network to get prices for. */
+  network: Network;
+  /** The contract address to get prices for. */
+  address: string;
+}
+
+/**
+ * The parameter field of {@link PricesNamespace.getTokenPriceBySymbol}.
+ * Contains the list of token symbols to get prices for.
+ *
+ * @public
+ */
+export interface GetTokenPriceBySymbolRequest {
+  /** The token symbols to get prices for. */
+  symbols: string[];
+}
+
+/**
+ * The response type of {@link PricesNamespace.getTokenPriceByAddress}.
+ * Contains an array of token price results for each requested address.
+ *
+ * @public
+ */
+export interface GetTokenPriceByAddressResponse {
+  /** The token price data for each requested address. */
+  data: TokenPriceByAddressResult[];
+}
+
+/**
+ * The response type of {@link PricesNamespace.getTokenPriceBySymbol}.
+ * Contains an array of token price results for each requested symbol.
+ *
+ * @public
+ */
+export interface GetTokenPriceBySymbolResponse {
+  /** The token price data for each requested symbol. */
+  data: TokenPriceBySymbolResult[];
+}
+
+/**
+ * Represents a token's price information at a specific point in time.
+ *
+ * @public
+ */
+export interface TokenPrice {
+  /** The currency the price is denominated in (e.g. 'usd'). */
+  currency: string;
+  /** The price value as a string to preserve precision. */
+  value: string;
+  /** ISO timestamp of when the price was last updated. */
+  lastUpdatedAt: string;
+}
+
+/**
+ * Error information returned when a token price request fails.
+ *
+ * @public
+ */
+export interface TokenPriceError {
+  /** The error message describing why the request failed. */
+  message: string;
+}
+
+/**
+ * The result object returned for each address in a
+ * {@link GetTokenPriceByAddressResponse}.
+ *
+ * @public
+ */
+export interface TokenPriceByAddressResult {
+  /** The network the token is on. */
+  network: string;
+  /** The token's contract address. */
+  address: string;
+  /** Array of price data for the token. Empty if there was an error. */
+  prices: TokenPrice[];
+  /** Error information if the request failed, null otherwise. */
+  error: TokenPriceError | null;
+}
+
+/**
+ * The result object returned for each symbol in a
+ * {@link GetTokenPriceBySymbolResponse}.
+ *
+ * @public
+ */
+export interface TokenPriceBySymbolResult {
+  /** The token symbol that was queried. */
+  symbol: string;
+  /** Array of price data for the token. Empty if there was an error. */
+  prices: TokenPrice[];
+  /** Error information if the request failed, null otherwise. */
+  error: TokenPriceError | null;
+}
+
+/**
+ * Valid time intervals for historical price data.
+ *
+ * @public
+ */
+export enum HistoricalPriceInterval {
+  /** 5-minute intervals */
+  FIVE_MINUTE = '5m',
+  /** 1-hour intervals */
+  ONE_HOUR = '1h',
+  /** 1-day intervals */
+  ONE_DAY = '1d'
+}
+
+/**
+ * Historical price data point.
+ *
+ * @public
+ */
+export interface HistoricalPriceDataPoint {
+  /** Price value as a string to preserve precision */
+  value: string;
+  /** ISO timestamp for the price data point */
+  timestamp: string;
+}
+
+/**
+ * Base interface for historical price responses.
+ *
+ * @public
+ */
+interface BaseHistoricalPriceResponse {
+  /** Currency the prices are denominated in */
+  currency: string;
+  /** Array of historical price data points */
+  data: HistoricalPriceDataPoint[];
+}
+
+/**
+ * Response type for historical prices by symbol requests.
+ *
+ * @public
+ */
+export interface HistoricalPriceBySymbolResponse
+  extends BaseHistoricalPriceResponse {
+  /** Token symbol that was queried */
+  symbol: string;
+}
+
+/**
+ * Response type for historical prices by network/address requests.
+ *
+ * @public
+ */
+export interface HistoricalPriceByAddressResponse
+  extends BaseHistoricalPriceResponse {
+  /** Network that was queried */
+  network: string;
+  /** Contract address that was queried */
+  address: string;
+}
+
+/**
+ * Type helper to infer the correct response type based on the request type.
+ *
+ * @public
+ */
+export type HistoricalPriceResponse =
+  | HistoricalPriceBySymbolResponse
+  | HistoricalPriceByAddressResponse;

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -29,10 +29,15 @@ export function getAlchemyWebhookHttpUrl(): string {
   return 'https://dashboard.alchemy.com/api';
 }
 
+export function getPricesBaseUrl(apiKey: string): string {
+  return `https://api.g.alchemy.com/prices/v1/${apiKey}`;
+}
+
 export enum AlchemyApiType {
   BASE,
   NFT,
-  WEBHOOK
+  WEBHOOK,
+  PRICES
 }
 
 /**

--- a/test/integration/prices.test.ts
+++ b/test/integration/prices.test.ts
@@ -1,0 +1,167 @@
+import { Alchemy, Network } from '../../src';
+import {
+  HistoricalPriceInterval,
+  TokenAddressRequest
+} from '../../src/types/prices-types';
+import { loadAlchemyEnv } from '../test-util';
+
+jest.setTimeout(50000);
+
+describe('Prices API Integration Tests', () => {
+  let alchemy: Alchemy;
+
+  beforeAll(async () => {
+    await loadAlchemyEnv();
+    alchemy = new Alchemy({
+      apiKey: process.env.ALCHEMY_API_KEY
+    });
+  });
+
+  describe('getTokenPriceByAddress()', () => {
+    it('should get token prices by address', async () => {
+      const addresses: TokenAddressRequest[] = [
+        {
+          network: Network.ETH_MAINNET,
+          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599' // WBTC
+        },
+        {
+          network: Network.MATIC_MAINNET,
+          address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619' // WETH on Polygon
+        }
+      ];
+
+      const response = await alchemy.prices.getTokenPriceByAddress(addresses);
+
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBe(2);
+
+      // Check WBTC response
+      const wbtcResult = response.data.filter(
+        result => result.address === addresses[0].address
+      )[0];
+      expect(wbtcResult.network).toBe('eth-mainnet');
+      expect(wbtcResult.address).toBe(addresses[0].address);
+      expect(wbtcResult.prices.length).toBeGreaterThan(0);
+      expect(wbtcResult.error).toBeUndefined();
+      expect(parseFloat(wbtcResult.prices[0].value)).toBeGreaterThan(0);
+      expect(wbtcResult.prices[0].currency).toBe('usd');
+      expect(new Date(wbtcResult.prices[0].lastUpdatedAt)).toBeTruthy();
+
+      // Check WETH response
+      const wethResult = response.data.filter(
+        result => result.address === addresses[1].address
+      )[0];
+      expect(wethResult.network).toBe('polygon-mainnet');
+      expect(wethResult.address).toBe(addresses[1].address);
+      expect(wethResult.error).toBeUndefined();
+      expect(parseFloat(wethResult.prices[0].value)).toBeGreaterThan(0);
+      expect(wethResult.prices[0].currency).toBe('usd');
+      expect(new Date(wethResult.prices[0].lastUpdatedAt)).toBeTruthy();
+    });
+
+    it('should handle invalid addresses', async () => {
+      const addresses: TokenAddressRequest[] = [
+        {
+          network: Network.ETH_MAINNET,
+          address: '0x0000000000000000000000000000000000000000'
+        }
+      ];
+
+      const response = await alchemy.prices.getTokenPriceByAddress(addresses);
+
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBe(1);
+      expect(response.data[0].error).toBeDefined();
+      expect(response.data[0].prices).toHaveLength(0);
+    });
+
+    it('should handle invalid networks', async () => {
+      const addresses: TokenAddressRequest[] = [
+        {
+          network: 'invalid-network' as any,
+          address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+        }
+      ];
+
+      const response = await alchemy.prices.getTokenPriceByAddress(addresses);
+      expect(response.data[0].error).toBeDefined();
+      expect(response.data[0].prices).toHaveLength(0);
+    });
+  });
+
+  describe('getTokenPriceBySymbol()', () => {
+    it('should get token prices by symbol', async () => {
+      const symbols = ['AAVE', 'UNI', 'INVALID_SYMBOL'];
+      const response = await alchemy.prices.getTokenPriceBySymbol(symbols);
+
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBe(3);
+
+      // Check AAVE response
+      const aaveResult = response.data[0];
+      expect(aaveResult.symbol).toBe('AAVE');
+      expect(aaveResult.prices.length).toBeGreaterThan(0);
+      expect(aaveResult.error).toBeUndefined();
+      expect(parseFloat(aaveResult.prices[0].value)).toBeGreaterThan(0);
+      expect(aaveResult.prices[0].currency).toBe('usd');
+      expect(new Date(aaveResult.prices[0].lastUpdatedAt)).toBeTruthy();
+
+      // Check UNI response
+      const uniResult = response.data[1];
+      expect(uniResult.symbol).toBe('UNI');
+      expect(uniResult.prices.length).toBeGreaterThan(0);
+      expect(uniResult.error).toBeUndefined();
+      expect(parseFloat(uniResult.prices[0].value)).toBeGreaterThan(0);
+
+      // Check invalid symbol response
+      const invalidResult = response.data[2];
+      expect(invalidResult.symbol).toBe('INVALID_SYMBOL');
+      expect(invalidResult.prices).toHaveLength(0);
+      expect(invalidResult.error).toBeDefined();
+    });
+  });
+
+  describe('getHistoricalPriceBySymbol()', () => {
+    it('should get historical prices by symbol', async () => {
+      const response = await alchemy.prices.getHistoricalPriceBySymbol(
+        'UNI',
+        1704067200,
+        '2024-01-02T00:00:00Z',
+        HistoricalPriceInterval.ONE_HOUR
+      );
+
+      expect(response.symbol).toBe('UNI');
+      expect(response.currency).toBe('usd');
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+
+      const dataPoint = response.data[0];
+      expect(parseFloat(dataPoint.value)).toBeGreaterThan(0);
+      expect(new Date(dataPoint.timestamp)).toBeTruthy();
+    });
+  });
+
+  describe('getHistoricalPriceByAddress()', () => {
+    it('should get historical prices by address', async () => {
+      const response = await alchemy.prices.getHistoricalPriceByAddress(
+        Network.ETH_MAINNET,
+        '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984', // UNI token
+        '2024-01-01T00:00:00Z',
+        1731693158,
+        HistoricalPriceInterval.ONE_DAY
+      );
+
+      expect(response.network).toBe('eth-mainnet');
+      expect(response.address).toBe(
+        '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'
+      );
+      expect(response.currency).toBe('usd');
+      expect(response.data).toBeDefined();
+      expect(response.data.length).toBeGreaterThan(0);
+
+      const dataPoint = response.data[0];
+      expect(parseFloat(dataPoint.value)).toBeGreaterThan(0);
+      expect(new Date(dataPoint.timestamp)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Adding new Token Price methods (see [documentation](https://docs.alchemy.com/reference/get-token-prices-by-symbol)). These methods go in a new `PricesNamspace` that can be accessed via `alchemy.prices`.

Currently working on a follow up PR to integrate these into the existing token balance endpoints, which I'll add before releasing.

Verified e2e behavior with integration tests
