### PR TITLE
add webhook naming via sdk

### DIFF
--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -55,7 +55,7 @@ import { AlchemyConfig } from './alchemy-config';
  *
  * Do not call this constructor directly. Instead, instantiate an Alchemy object
  * with `const alchemy = new Alchemy(config)` and then access the notify
- * namespace via `alchemy.notify`.
+ * namespace via `alchemy. `.
  */
 export class NotifyNamespace {
   /** @internal */
@@ -519,6 +519,7 @@ export class NotifyNamespace {
       webhook_type: type,
       webhook_url: url,
       ...(appId && { app_id: appId }),
+      ...(params.name && { name: params.name }),
 
       // Only include the filters/addresses in the final response if they're defined
       ...nftFilterObj,
@@ -667,7 +668,9 @@ function parseRawWebhook(rawWebhook: RawWebhook): Webhook {
     signingKey: rawWebhook.signing_key,
     version: rawWebhook.version as WebhookVersion,
     // Only include the appId in the final response if it's defined
-    ...(rawWebhook.app_id !== undefined && { appId: rawWebhook.app_id })
+    ...(rawWebhook.app_id !== undefined && { appId: rawWebhook.app_id }),
+    // Only include the name in the final response if it's defined
+    ...(rawWebhook.name !== undefined && { name: rawWebhook.name })
   };
 }
 

--- a/src/api/notify-namespace.ts
+++ b/src/api/notify-namespace.ts
@@ -55,7 +55,7 @@ import { AlchemyConfig } from './alchemy-config';
  *
  * Do not call this constructor directly. Instead, instantiate an Alchemy object
  * with `const alchemy = new Alchemy(config)` and then access the notify
- * namespace via `alchemy. `.
+ * namespace via `alchemy.notify`.
  */
 export class NotifyNamespace {
   /** @internal */

--- a/src/internal/raw-interfaces.ts
+++ b/src/internal/raw-interfaces.ts
@@ -255,6 +255,7 @@ export interface RawWebhook {
   signing_key: string;
   version: string;
   app_id?: string;
+  name?: string;
 }
 
 export interface RawWebhookPagination {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,6 +6,7 @@ import {
 import { BigNumberish } from '@ethersproject/bignumber';
 import { ConnectionInfo } from '@ethersproject/web';
 
+import { NotifyNamespace } from '../api/notify-namespace';
 import {
   ERC1155Metadata,
   NftRefreshState,
@@ -1238,6 +1239,14 @@ export interface CustomGraphqlWebhookConfig {
 }
 
 /**
+ * Base interface for all webhook parameters that includes common fields.
+ */
+export interface BaseWebhookParams {
+  /** Optional name for the webhook. */
+  name?: string;
+}
+
+/**
  * Params to pass in when calling {@link NotifyNamespace.createWebhook} in order
  * to create a {@link MinedTransactionWebhook} or {@link DroppedTransactionWebhook}.
  *
@@ -1248,18 +1257,16 @@ export interface CustomGraphqlWebhookConfig {
  * This is a temporary workaround for now. We're planning on detecting the app
  * id from the provided api key directly. Stay tuned!
  */
-export interface TransactionWebhookParams {
+export interface TransactionWebhookParams extends BaseWebhookParams {
   /** The app id of the project to create the webhook on. */
   appId: string;
-  /** Optional name for the webhook. */
-  name?: string;
 }
 
 /**
  * Params to pass in when calling {@link NotifyNamespace.createWebhook} in order
  * to create a {@link NftActivityWebhook} or {@link NftMetadataUpdateWebhook}.
  */
-export interface NftWebhookParams {
+export interface NftWebhookParams extends BaseWebhookParams {
   /** Array of NFT filters the webhook should track. */
   filters: NftFilter[];
   /**
@@ -1267,15 +1274,13 @@ export interface NftWebhookParams {
    * created on network of the app provided in the api key config.
    */
   network?: Network;
-  /** Optional name for the webhook. */
-  name?: string;
 }
 
 /**
  * Params to pass in when calling {@link NotifyNamespace.createWebhook} in order
  * to create a {@link CustomGraphqlWebhook}
  */
-export interface CustomGraphqlWebhookParams {
+export interface CustomGraphqlWebhookParams extends BaseWebhookParams {
   /** GraphQL query */
   graphqlQuery: string;
   /**
@@ -1302,15 +1307,13 @@ export interface CustomGraphqlWebhookParams {
    * change in the API.
    */
   appId?: string;
-  /** Optional name for the webhook. */
-  name?: string;
 }
 
 /**
  * Params to pass in when calling {@link NotifyNamespace.createWebhook} in order
  * to create a {@link AddressActivityWebhook}.
  */
-export interface AddressWebhookParams {
+export interface AddressWebhookParams extends BaseWebhookParams {
   /** Array of addresses the webhook should activity for. */
   addresses: string[];
   /**
@@ -1318,8 +1321,6 @@ export interface AddressWebhookParams {
    * created on network of the app provided in the api key config.
    */
   network?: Network;
-  /** Optional name for the webhook. */
-  name?: string;
 }
 
 /** NFT to track on a {@link NftActivityWebhook} or {@link NftMetadataUpdateWebhook}. */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1129,6 +1129,8 @@ export interface Webhook {
    * {@link MinedTransactionWebhook} and {@link DroppedTransactionWebhook}
    */
   appId?: string;
+  /** The name of the webhook. */
+  name?: string;
 }
 
 /** The version of the webhook. All newly created webhooks default to V2. */
@@ -1249,6 +1251,8 @@ export interface CustomGraphqlWebhookConfig {
 export interface TransactionWebhookParams {
   /** The app id of the project to create the webhook on. */
   appId: string;
+  /** Optional name for the webhook. */
+  name?: string;
 }
 
 /**
@@ -1263,6 +1267,8 @@ export interface NftWebhookParams {
    * created on network of the app provided in the api key config.
    */
   network?: Network;
+  /** Optional name for the webhook. */
+  name?: string;
 }
 
 /**
@@ -1296,6 +1302,8 @@ export interface CustomGraphqlWebhookParams {
    * change in the API.
    */
   appId?: string;
+  /** Optional name for the webhook. */
+  name?: string;
 }
 
 /**
@@ -1310,6 +1318,8 @@ export interface AddressWebhookParams {
    * created on network of the app provided in the api key config.
    */
   network?: Network;
+  /** Optional name for the webhook. */
+  name?: string;
 }
 
 /** NFT to track on a {@link NftActivityWebhook} or {@link NftMetadataUpdateWebhook}. */


### PR DESCRIPTION
add name as an option to the create-webhook api SDK - the name parameter already exists on the create-webhook alchemy api

ASANA TASK: https://app.asana.com/1/1129441638109975/project/1208969177908953/task/1209648386732973?focus=true