### PR TITLE
Add missing originalUrl from NFT animation type

### DIFF
--- a/src/types/nft-types.ts
+++ b/src/types/nft-types.ts
@@ -1267,6 +1267,8 @@ export interface Nft {
   animation?: {
     /** URL of the animation stored in Alchemy's cache. */
     cachedUrl?: string;
+    /** The original URL of the animation as stored on the contract. */
+    originalUrl?: string;
     /** The type of the animation media. */
     contentType?: string;
     /** The size of the animation in bytes. */


### PR DESCRIPTION
This looks like an omission since the API returns `originalUrl` as part of animations
![Screenshot from 2025-05-14 17-45-24](https://github.com/user-attachments/assets/a89fdf09-fa03-41a1-920f-b7195d664055)
