### PR TITLE
fix: remove leading 0s in hex string

### DIFF
--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import { hexValue } from '@ethersproject/bytes';
 
 /**
  * Converts a hex string to a decimal number.
@@ -17,7 +18,7 @@ export function fromHex(hexString: string): number {
  * @public
  */
 export function toHex(num: number): string {
-  return BigNumber.from(num).toHexString();
+  return hexValue(num);
 }
 
 /**


### PR DESCRIPTION
Some nodes like polygon error when leading 0s are sent in a hex string.

Follows guidance from https://github.com/ethers-io/ethers.js/discussions/3743