### PR TITLE
feat: Added Botanix, Humanity, Rise. Deprecated Celo, Fantom, Geist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Minor Changes
 
+## 3.6.2
+
+### Minor Changes
+
+- Added Botanix Mainnet, Testnet; Humanity Mainnet; Rise Testnet
+- Deprecated Celo Baklava; Fantom Testnet; Geist Mainnet, Polter 
+
 ## 3.6.1
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The SDK currently supports the following chains (chains with '(d)' after are dep
 - **Anime**: Mainnet, Sepolia
 - **Story**: Mainnet, Aeneid
 - **Megaeth**: Testnet
+- **Botanix**: Mainnet, Testnet
+- **Humanity**: Mainnet
+- **Rise**: Testnet
 
 You can find per-method documentation of the Alchemy SDK endpoints at the [Alchemy Docs linked in the sidebar](https://docs.alchemy.com/reference/alchemy-sdk-quickstart).
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -134,6 +134,7 @@ export enum Network {
   LINEA_MAINNET = 'linea-mainnet',
   LINEA_SEPOLIA = 'linea-sepolia',
   FANTOM_MAINNET = 'fantom-mainnet',
+  /** @deprecated */
   FANTOM_TESTNET = 'fantom-testnet',
   ZETACHAIN_MAINNET = 'zetachain-mainnet',
   ZETACHAIN_TESTNET = 'zetachain-testnet',
@@ -152,6 +153,7 @@ export enum Network {
   AVAX_FUJI = 'avax-fuji',
   CELO_MAINNET = 'celo-mainnet',
   CELO_ALFAJORES = 'celo-alfajores',
+  /** @deprecated */
   CELO_BAKLAVA = 'celo-baklava',
   METIS_MAINNET = 'metis-mainnet',
   OPBNB_MAINNET = 'opbnb-mainnet',
@@ -180,7 +182,9 @@ export enum Network {
   APECHAIN_CURTIS = 'apechain-curtis',
   LENS_MAINNET = 'lens-mainnet',
   LENS_SEPOLIA = 'lens-sepolia',
+  /** @deprecated */
   GEIST_MAINNET = 'geist-mainnet',
+  /** @deprecated */
   GEIST_POLTER = 'geist-polter',
   LUMIA_PRISM = 'lumia-prism',
   LUMIA_TESTNET = 'lumia-testnet',
@@ -211,7 +215,11 @@ export enum Network {
   ANIME_SEPOLIA = 'anime-sepolia',
   STORY_MAINNET = 'story-mainnet',
   STORY_AENEID = 'story-aeneid',
-  MEGAETH_TESTNET = 'megaeth-testnet'
+  MEGAETH_TESTNET = 'megaeth-testnet',
+  BOTANIX_MAINNET = 'botanix-mainnet',
+  BOTANIX_TESTNET = 'botanix-testnet',
+  HUMANITY_MAINNET = 'humanity-mainnet',
+  RISE_TESTNET = 'rise-testnet'
 }
 
 /** Token Types for the `getTokenBalances()` endpoint. */

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -154,7 +154,11 @@ export const EthersNetwork = {
   [Network.ANIME_SEPOLIA]: 'anime-sepolia',
   [Network.STORY_MAINNET]: 'story-mainnet',
   [Network.STORY_AENEID]: 'story-aeneid',
-  [Network.MEGAETH_TESTNET]: 'megaeth-testnet'
+  [Network.MEGAETH_TESTNET]: 'megaeth-testnet',
+  [Network.BOTANIX_MAINNET]: 'botanix-mainnet',
+  [Network.BOTANIX_TESTNET]: 'botanix-testnet',
+  [Network.HUMANITY_MAINNET]: 'humanity-mainnet',
+  [Network.RISE_TESTNET]: 'rise-testnet'
 };
 
 /**
@@ -550,6 +554,22 @@ export const CustomNetworks: { [key: string]: NetworkFromEthers } = {
   'megaeth-testnet': {
     chainId: 0x18c6,
     name: 'megaeth-testnet'
+  },
+  'botanix-mainnet': {
+    chainId: 0xe34,
+    name: 'botanix-mainnet'
+  },
+  'botanix-testnet': {
+    chainId: 0xe35,
+    name: 'botanix-testnet'
+  },
+  'humanity-mainnet': {
+    chainId: 0x6a96a9,
+    name: 'humanity-mainnet'
+  },
+  'rise-testnet': {
+    chainId: 0xaa39db,
+    name: 'rise-testnet'
   }
 };
 


### PR DESCRIPTION
- Added Botanix Mainnet, Testnet; Humanity Mainnet; Rise Testnet
- Deprecated Celo Baklava; Fantom Testnet; Geist Mainnet, Polter

Confirmed deprecated (or retired) status in Daikon.