### PR TITLE
Fix typos in comments

### DIFF
--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -163,7 +163,7 @@ export const EthersNetwork = {
 
 /**
  * Mapping of network names to their corresponding Ethers Network objects. These
- * networks are not yet supported by Ethers and are listed here to be overriden
+ * networks are not yet supported by Ethers and are listed here to be overridden
  * in the provider.
  */
 export const CustomNetworks: { [key: string]: NetworkFromEthers } = {

--- a/test/unit/websocket-provider.test.ts
+++ b/test/unit/websocket-provider.test.ts
@@ -138,7 +138,7 @@ describe('AlchemyWebSocketProvider', () => {
     deferred: Deferred<void>
   ): void {
     for (const message of messages) {
-      // Use setImmediate to allow provder to pick up message.
+      // Use setImmediate to allow provider to pick up message.
       setImmediate(() => {
         mockServer.clients()[0].send(
           JSON.stringify({


### PR DESCRIPTION


This PR fixes minor typos in code comments across two files:

- **`src/util/const.ts`**: Fixed "overriden" → "overridden" in comment on line 166
- **`test/unit/websocket-provider.test.ts`**: Fixed "provder" → "provider" in comment on line 141

