### PR TITLE
portifolio-types: fix response type

### DIFF
--- a/src/types/portfolio-types.ts
+++ b/src/types/portfolio-types.ts
@@ -1,6 +1,6 @@
 import { Contract } from '../api/alchemy-contract';
 import { Nft } from './nft-types';
-import { TokenPriceByAddressResult } from './prices-types';
+import { TokenPrice } from './prices-types';
 import { Network, TokenMetadataResponse, TransactionReceipt } from './types';
 
 /**
@@ -53,7 +53,7 @@ export interface GetTokensByWalletResponse {
       /** Optional metadata about the token, potentially including name, symbol, decimals, etc. */
       tokenMetadata?: TokenMetadataResponse;
       /** Optional pricing data for the token, such as current value or historical prices. */
-      tokenPrices?: TokenPriceByAddressResult;
+      tokenPrices: TokenPrice[];
     }>;
     /** A string used for pagination to retrieve additional results if available. */
     pageKey: string;


### PR DESCRIPTION
Fix the return type


The tokenPrices property is not a `TokenPriceByAddressResult`, it is a `TokenPrice[]`
Example of response


```json
{
  "address": "0x096d20b5d3acd52b16f0cd716ba571bbb3959052",
  "network": "arb-mainnet",
  "tokenAddress": "0x0721b3c9f19cfef1d622c918dcd431960f35e060",
  "tokenBalance": "0x00000000000000000000000000000000000000000000000c3042a81f7d6fe000",
  "tokenMetadata": {
    "decimals": 18,
    "logo": null,
    "name": "SYNTHR",
    "symbol": "SYNTH"
  },
  "tokenPrices": [
    {
      "currency": "usd",
      "value": "0.0000680155",
      "lastUpdatedAt": "2025-07-18T16:31:46Z"
    }
  ]
},
{
  "address": "0x096d20b5d3acd52b16f0cd716ba571bbb3959052",
  "network": "eth-mainnet",
  "tokenAddress": "0x0a527683c3154f5f9e1b4203ef4d05962b2411bf",
  "tokenBalance": "0x00000000000000000000000000000000000000000000000000000000000001db",
  "tokenMetadata": {
    "decimals": 2,
    "logo": null,
    "name": "",
    "symbol": ""
  },
  "tokenPrices": []
}
```